### PR TITLE
IE 8-9 CORS request

### DIFF
--- a/source/skyway.js
+++ b/source/skyway.js
@@ -976,7 +976,7 @@
     this._requestServerInfo = function(method, url, callback, params) {
       var xhr = new window.XMLHttpRequest();
       /*  FOR IE 8-9 CORS REQUEST */
-      if (window.XDomainRequest  && !navigator.userAgent.indexOf('IE 10'))
+      if (window.XDomainRequest  && navigator.userAgent.indexOf('IE 10') == -1)
       {
           xhr = new XDomainRequest();
       }


### PR DESCRIPTION
Fix for IE 9 CORS request issue.

Tests show XMLHttpRequest does not sent the origin header,
XDomainRequest does.

See

http://blogs.msdn.com/b/webdev/archive/2013/10/28/sending-a-cors-request-in-ie.aspx
