### PR TITLE
Added a code to store all logs globally

### DIFF
--- a/source/skylink-debug.js
+++ b/source/skylink-debug.js
@@ -74,8 +74,8 @@ var _enableDebugMode = false;
  * @since 0.5.4
  */
 var _logFn = function(logLevel, message, debugObject) {
-  SkylinkJSLogs = window.SkylinkJSLogs ? SkylinkJSLogs:[];
-  SkylinkJSLogs.push([new Date().getTime(),logLevel,message]);
+  Temasys.SkylinkJSLogs = Temasys.SkylinkJSLogs ? Temasys.SkylinkJSLogs:[];
+  Temasys.SkylinkJSLogs.push([new Date().getTime(),logLevel,message]);
 
   var levels = ['error', 'warn', 'info', 'log', 'debug'];
   var outputLog = _LOG_KEY;


### PR DESCRIPTION
All logs whether shown or not, should be kept. I’ve added a global
variable SkylinkJSLogs that will keep all of the log messages.

My reason for having his is so that I can better debug remote sessions.
It is better for me to upload the log to the server and view it there
than to ask for a screen share which may not be possible or reasonable.
