### PR TITLE
Fix for socket.io upgraded dependency 1.2.1 mistaken as 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "prestart": "./start.sh &"
   },
   "dependencies": {
-    "socket.io-client": "1.2.0",
+    "socket.io-client": "1.2.1",
     "adapterjs": "https://github.com/Temasys/AdapterJS/archive/0.9.3.tar.gz"
   },
   "devDependencies": {


### PR DESCRIPTION
- Fix for upgraded socket.io is stated 1.2.1 in modules but stated 1.2.0 in package.json
