### PR TITLE
Fixes the "Firefox on Windows doesn't work" bug

### DIFF
--- a/publish/skylink.complete.js
+++ b/publish/skylink.complete.js
@@ -10610,6 +10610,7 @@ Skylink.prototype._doOffer = function(targetMid, peerBrowser) {
     if (window.webrtcDetectedBrowser === 'firefox' &&
       window.navigator.platform.indexOf('Win') === 0 &&
       peerBrowser.agent !== 'firefox' &&
+      peerBrowser.agent !== 'MCU' &&
       peerBrowser.os.indexOf('Mac') === 0) {
       beOfferer = false;
     }


### PR DESCRIPTION
When the client uses Windows + Firefox with MCU enabled, peerBrowser.os is undefined (because the peer considered here is the MCU). So peerBrowser.os.indexOf(...) makes the program stop. Bug fixed by checking fisrt whether the peer is a real peer or the MCU.