### PR TITLE
Ess 309 privileged

### DIFF
--- a/source/peer-privileged.js
+++ b/source/peer-privileged.js
@@ -1,18 +1,32 @@
 /**
- * The types of Privileged states available
- * @attribute PRIVILEGED_STATE
+ * The types of get peers states available
+ * @attribute GET_PEERS_STATE
  * @type JSON
  * @param {String} ENQUIRED Privileged peer already enquired signaling for list of peers
  * @param {String} RECEIVED Privileged peer received list of peers from signaling
+ * @readOnly
+ * @component Peer
+ * @for Skylink
+ * @since 0.6.1
+ */
+Skylink.prototype.GET_PEERS_STATE = {
+	ENQUIRED: 'enquired',
+	RECEIVED: 'received',
+};
+
+/**
+ * The types of peer introduction states available
+ * @attribute INTRODUCE_STATE
+ * @type JSON
+ * @param {String} INTRODUCING Privileged peer sent the introduction signal
  * @param {String} ERROR Error happened during peer introduction
  * @readOnly
  * @component Peer
  * @for Skylink
  * @since 0.6.1
  */
-Skylink.prototype.PRIVILEGED_STATE = {
-	ENQUIRED: 'enquired',
-	RECEIVED: 'received',
+Skylink.prototype.INTRODUCE_STATE = {
+	INTRODUCING: 'introducing',
 	ERROR: 'error'
 };
 
@@ -70,6 +84,35 @@ Skylink.prototype._peerList = null;
  * @method getPeers
  * @param {Boolean} [showAll=false] If true, include privileged peers in the list. False by default.
  * @param {Function} [callback] Callback when peer list was returned
+ *   Default signature: function(error object, success object)
+ * @example
+ *
+ *   // To get list of unprivileged peers only
+ *   SkylinkDemo.getPeers();
+ *
+ *   // To get list of all peers, including other privileged peers
+ *   SkylinkDemo.getPeers(true);
+ *
+ *   // To get a list of unprivileged peers then invoke the callback
+ *   SkylinkDemo.getPeers(function(error, success){
+ *     if (error){
+ *       console.log('Error happened. Can not retrieve list of peers');
+ *     }
+ *     else{
+ *       console.log('Success fully retrieved list of peers', success);
+ *     }
+ *   });
+ *   
+ *   // To get a list of all peers then invoke the callback
+ *   SkylinkDemo.getPeers(true, function(error, success){
+ *     if (error){
+ *       console.log('Error happened. Can not retrieve list of peers');
+ *     }
+ *     else{
+ *       console.log('Success fully retrieved list of peers', success);
+ *     }
+ *   });
+ *   
  * @public
  * @component Peer
  * @for Skylink
@@ -102,14 +145,15 @@ Skylink.prototype.getPeers = function(showAll, callback){
 		parentKey: self._parentKey,
 		showAll: showAll || false
 	});
-	self._trigger('privilegedStateChange',self.PRIVILEGED_STATE.ENQUIRED, self._user.sid, null, null, null);
-	log.log('Enquired signaling for peers within the realm');
+	self._trigger('getPeersStateChange',self.GET_PEERS_STATE.ENQUIRED, self._user.sid, null);
+
+	log.log('Enquired server for peers within the realm');
 
 	if (typeof callback === 'function'){
-		self.once('privilegedStateChange', function(state, privilegedPeerId, sendingPeerId, receivingPeerId, peerList){
+		self.once('getPeersStateChange', function(state, privilegedPeerId, peerList){
 			callback(null, peerList);
-		}, function(state, privilegedPeerId, sendingPeerId, receivingPeerId, peerList){
-			return state === self.PRIVILEGED_STATE.RECEIVED;
+		}, function(state, privilegedPeerId, peerList){
+			return state === self.GET_PEERS_STATE.RECEIVED;
 		});
 	}
 
@@ -129,6 +173,7 @@ Skylink.prototype.introducePeer = function(sendingPeerId, receivingPeerId){
 	var self = this;
 	if (!self._isPrivileged){
 		log.warn('Please upgrade your key to privileged to use this function');
+		self._trigger('introduceStateChange', self.INTRODUCE_STATE.ERROR, self._user.sid, sendingPeerId, receivingPeerId, 'notPrivileged');
 		return;
 	}
 	self._sendChannelMessage({
@@ -136,7 +181,7 @@ Skylink.prototype.introducePeer = function(sendingPeerId, receivingPeerId){
 		sendingPeerId: sendingPeerId,
 		receivingPeerId: receivingPeerId
 	});
-	self._trigger('privilegedStateChange', self.PRIVILEGED_STATE.INTRODUCE, self._user.sid, sendingPeerId, receivingPeerId, self._peerList);
+	self._trigger('introduceStateChange', self.INTRODUCE_STATE.INTRODUCING, self._user.sid, sendingPeerId, receivingPeerId, null);
 	log.log('Introducing',sendingPeerId,'to',receivingPeerId);
 };
 

--- a/source/peer-privileged.js
+++ b/source/peer-privileged.js
@@ -2,9 +2,9 @@
  * The types of Privileged states available
  * @attribute PRIVILEGED_STATE
  * @type JSON
- * @param {String} ENQUIRED Privileged peer already enquired signaling for list of unprivileged peers
- * @param {String} RECEIVED Privileged peer received list of unprivileged peers from signaling
- * @param {String} INTRODUCED Privileged peer introduced 2 unprivileged peers to each other
+ * @param {String} ENQUIRED Privileged peer already enquired signaling for list of peers
+ * @param {String} RECEIVED Privileged peer received list of peers from signaling
+ * @param {String} ERROR Error happened during peer introduction
  * @readOnly
  * @component Peer
  * @for Skylink
@@ -13,7 +13,6 @@
 Skylink.prototype.PRIVILEGED_STATE = {
 	ENQUIRED: 'enquired',
 	RECEIVED: 'received',
-	INTRODUCED: 'introduced',
 	ERROR: 'error'
 };
 
@@ -55,8 +54,8 @@ Skylink.prototype._isPrivileged = false;
 Skylink.prototype._parentKey = null;
 
 /**
- * List of unprivileged peers retrieved from signaling
- * @attribute _unprivilegedPeerList
+ * List of peers retrieved from signaling
+ * @attribute _peerList
  * @type Object
  * @default null
  * @private
@@ -64,18 +63,19 @@ Skylink.prototype._parentKey = null;
  * @for Skylink
  * @since 0.6.1
  */
-Skylink.prototype._unprivilegedPeerList = null;
+Skylink.prototype._peerList = null;
 
 /**
- * For privileged user to enquire signaling to return the list of unprivileged peers under the same parent.
- * @method getUnprivilegedPeers
- * @param {Function} [callback] Callback when unprivileged peer list was returned
+ * For privileged user to enquire signaling to return the list of peers under the same parent.
+ * @method getPeers
+ * @param {Boolean} [showAll=false] If true, include privileged peers in the list. False by default.
+ * @param {Function} [callback] Callback when peer list was returned
  * @public
  * @component Peer
  * @for Skylink
  * @since 0.6.1
  */
-Skylink.prototype.getUnprivilegedPeers = function(callback){
+Skylink.prototype.getPeers = function(showAll, callback){
 	var self = this;
 	if (!self._isPrivileged){
 		log.warn('Please upgrade your key to privileged to use this function');
@@ -89,18 +89,26 @@ Skylink.prototype.getUnprivilegedPeers = function(callback){
 		log.warn('Parent key is not defined. Please authenticate again.');
 		return;	
 	}
+
+	// Only callback is provided
+	if (typeof showAll === 'function'){
+		callback = showAll;
+		showAll = false;
+	}
+
 	self._sendChannelMessage({
-		type: self._SIG_MESSAGE_TYPE.GET_UNPRIVILEGED,
+		type: self._SIG_MESSAGE_TYPE.GET_PEERS,
 		privilegedKey: self._appKey,
-		parentKey: self._parentKey
+		parentKey: self._parentKey,
+		showAll: showAll || false
 	});
 	self._trigger('privilegedStateChange',self.PRIVILEGED_STATE.ENQUIRED, self._user.sid, null, null, null);
-	log.log('Enquired signaling for unprivileged peers');
+	log.log('Enquired signaling for peers within the realm');
 
 	if (typeof callback === 'function'){
-		self.once('privilegedStateChange', function(state, privilegedPeerId, sendingPeerId, receivingPeerId, unprivilegedPeerList){
-			callback(null, unprivilegedPeerList);
-		}, function(state, privilegedPeerId, sendingPeerId, receivingPeerId, unprivilegedPeerList){
+		self.once('privilegedStateChange', function(state, privilegedPeerId, sendingPeerId, receivingPeerId, peerList){
+			callback(null, peerList);
+		}, function(state, privilegedPeerId, sendingPeerId, receivingPeerId, peerList){
 			return state === self.PRIVILEGED_STATE.RECEIVED;
 		});
 	}
@@ -108,7 +116,7 @@ Skylink.prototype.getUnprivilegedPeers = function(callback){
 };
 
 /**
- * For privileged peer to introduce 2 unprivileged peers to each other
+ * For privileged peer to introduce 2 peers to each other
  * @method introducePeer
  * @param {String} sendingPeerId Id of the peer who sends enter
  * @param {String} receivingPeerId Id of the peer who receives enter
@@ -128,7 +136,7 @@ Skylink.prototype.introducePeer = function(sendingPeerId, receivingPeerId){
 		sendingPeerId: sendingPeerId,
 		receivingPeerId: receivingPeerId
 	});
-	self._trigger('privilegedStateChange', self.PRIVILEGED_STATE.INTRODUCE, self._user.sid, sendingPeerId, receivingPeerId, self._unprivilegedPeerList);
+	self._trigger('privilegedStateChange', self.PRIVILEGED_STATE.INTRODUCE, self._user.sid, sendingPeerId, receivingPeerId, self._peerList);
 	log.log('Introducing',sendingPeerId,'to',receivingPeerId);
 };
 

--- a/source/skylink-events.js
+++ b/source/skylink-events.js
@@ -546,7 +546,7 @@ Skylink.prototype._EVENTS = {
    * @param {String} privilegedPeerId Id of privileged peer
    * @param {String} sendingPeerId Id of the peer who sends enter
    * @param {String} receivingPeerId Id of the peer who receives enter
-   * @param {Object} unprivilegedPeerList List of rooms and unprivileged peers under the realm
+   * @param {Object} peerList List of rooms and peers under the realm
    * @component Events
    * @for Skylink
    * @since 0.6.1

--- a/source/skylink-events.js
+++ b/source/skylink-events.js
@@ -541,17 +541,29 @@ Skylink.prototype._EVENTS = {
   systemAction: [],
 
   /**
-   * @event privilegedStateChange
-   * @param {String} state State of the introduction process
+   * @event getPeersStateChange
+   * @param {String} state State of the get peer process
    * @param {String} privilegedPeerId Id of privileged peer
-   * @param {String} sendingPeerId Id of the peer who sends enter
-   * @param {String} receivingPeerId Id of the peer who receives enter
    * @param {Object} peerList List of rooms and peers under the realm
    * @component Events
    * @for Skylink
    * @since 0.6.1
    */
-  privilegedStateChange: [],
+  getPeersStateChange: [],
+
+  /**
+   * @event introduceStateChange
+   * @param {String} state State of the introduction process
+   * @param {String} privilegedPeerId Id of privileged peer
+   * @param {String} sendingPeerId Id of the peer who sends enter
+   * @param {String} receivingPeerId Id of the peer who receives enter
+   * @param {String} reason Reason of introduce failure (if there is any)
+   * @component Events
+   * @for Skylink
+   * @since 0.6.1
+   */
+  introduceStateChange: [],
+
 };
 
 /**

--- a/source/socket-message.js
+++ b/source/socket-message.js
@@ -37,8 +37,11 @@ Skylink.prototype.SM_PROTOCOL_VERSION = '0.1.1';
  * @param {String} STREAM Broadcast when a Stream has ended. This is temporal.
  * @param {String} GROUP Messages are bundled together when messages are sent too fast to
  *   prevent server redirects over sending less than 1 second interval.
- * @param {String} GET_UNPRIVILEGED For privileged user to get the list of unprivileged peers under the same parent
- * @param {String} UNPRIVILEGED_LIST List of unprivileged peers under the same parent
+ * @param {String} GET_PEERS For privileged user to get the list of peers under the same parent
+ * @param {String} PEER_LIST List of peers under the same parent
+ * @param {String} INTRODUCE The message sent to signaling server to introduce 2 peers to each other.
+ * @param {String} INTRODUCE_ERROR The message received signaling server when peer introduction failed.
+ * @param {String} APPROACH The receiver of this message will send an enter to the target to initiate handshake.
  * @readOnly
  * @private
  * @component Message
@@ -64,8 +67,8 @@ Skylink.prototype._SIG_MESSAGE_TYPE = {
   PRIVATE_MESSAGE: 'private',
   STREAM: 'stream',
   GROUP: 'group',
-  GET_UNPRIVILEGED: 'getUnprivileged',
-  UNPRIVILEGED_LIST: 'unprivilegedList',
+  GET_PEERS: 'getPeers',
+  PEER_LIST: 'peerList',
   INTRODUCE: 'introduce',
   INTRODUCE_ERROR: 'introduceError',
   APPROACH: 'approach'
@@ -213,8 +216,8 @@ Skylink.prototype._processSingleMessage = function(message) {
   case this._SIG_MESSAGE_TYPE.ROOM_LOCK:
     this._roomLockEventHandler(message);
     break;
-  case this._SIG_MESSAGE_TYPE.UNPRIVILEGED_LIST:
-    this._unprivilegedListEventHandler(message);
+  case this._SIG_MESSAGE_TYPE.PEER_LIST:
+    this._peerListEventHandler(message);
     break;
   case this._SIG_MESSAGE_TYPE.INTRODUCE_ERROR:
     this._introduceErrorEventHandler(message);
@@ -229,21 +232,21 @@ Skylink.prototype._processSingleMessage = function(message) {
 };
 
 /**
- * Handles the UNPRIVILEGED_LIST Message event.
- * @method _unprivilegedListEventHandler
+ * Handles the PEER_LIST Message event.
+ * @method _peerListEventHandler
  * @param {JSON} message The Message object received.
- * @param {String} message.type Protocol step: <code>"unprivilegedList"</code>.
+ * @param {String} message.type Protocol step: <code>"peerList"</code>.
  * @param {Object} message.result Resulting object {room1: [peer1, peer2], room2: ...}
  * @private
  * @component Message
  * @for Skylink
  * @since 0.6.1
  */
-Skylink.prototype._unprivilegedListEventHandler = function(message){
+Skylink.prototype._peerListEventHandler = function(message){
   var self = this;
-  self._unprivilegedPeerList = message.result;
-  log.log(['Server', null, message.type, 'Received list of unprivileged peers'], self._unprivilegedPeerList);
-  self._trigger('privilegedStateChange',self.PRIVILEGED_STATE.RECEIVED, self._user.sid, null, null, self._unprivilegedPeerList);
+  self._peerList = message.result;
+  log.log(['Server', null, message.type, 'Received list of peers'], self._peerList);
+  self._trigger('privilegedStateChange',self.PRIVILEGED_STATE.RECEIVED, self._user.sid, null, null, self._peerList);
 };
 
 /**
@@ -262,10 +265,10 @@ Skylink.prototype._introduceErrorEventHandler = function(message){
   var self = this;
   log.log(['Server', null, message.type, 'Introduce failed. Reason: '+message.reason], message.peerId);
   if (message.reason.indexOf('sending')>-1){
-    self._trigger('privilegedStateChange',self.PRIVILEGED_STATE.ERROR, self._user.sid, message.peerId, null, self._unprivilegedPeerList);
+    self._trigger('privilegedStateChange',self.PRIVILEGED_STATE.ERROR, self._user.sid, message.peerId, null, self._peerList);
   }
   else{
-    self._trigger('privilegedStateChange',self.PRIVILEGED_STATE.ERROR, self._user.sid, null, message.peerId, self._unprivilegedPeerList); 
+    self._trigger('privilegedStateChange',self.PRIVILEGED_STATE.ERROR, self._user.sid, null, message.peerId, self._peerList); 
   }
 };
 

--- a/source/socket-message.js
+++ b/source/socket-message.js
@@ -246,7 +246,7 @@ Skylink.prototype._peerListEventHandler = function(message){
   var self = this;
   self._peerList = message.result;
   log.log(['Server', null, message.type, 'Received list of peers'], self._peerList);
-  self._trigger('privilegedStateChange',self.PRIVILEGED_STATE.RECEIVED, self._user.sid, null, null, self._peerList);
+  self._trigger('getPeersStateChange',self.GET_PEERS_STATE.RECEIVED, self._user.sid, self._peerList);
 };
 
 /**
@@ -255,7 +255,8 @@ Skylink.prototype._peerListEventHandler = function(message){
  * @param {JSON} message The Message object received.
  * @param {String} message.type Protocol step: <code>"introduceError"</code>.
  * @param {Object} message.reason The short explanation of the error cause
- * @param {Object} message.peerId Id of the peer whose error happened
+ * @param {Object} message.sendingPeerId Id of the peer initiating the handshake
+ * @param {Object} message.receivingPeerId Id of the peer receiving the handshake
  * @private
  * @component Message
  * @for Skylink
@@ -263,13 +264,8 @@ Skylink.prototype._peerListEventHandler = function(message){
  */
 Skylink.prototype._introduceErrorEventHandler = function(message){
   var self = this;
-  log.log(['Server', null, message.type, 'Introduce failed. Reason: '+message.reason], message.peerId);
-  if (message.reason.indexOf('sending')>-1){
-    self._trigger('privilegedStateChange',self.PRIVILEGED_STATE.ERROR, self._user.sid, message.peerId, null, self._peerList);
-  }
-  else{
-    self._trigger('privilegedStateChange',self.PRIVILEGED_STATE.ERROR, self._user.sid, null, message.peerId, self._peerList); 
-  }
+  log.log(['Server', null, message.type, 'Introduce failed. Reason: '+message.reason]);
+  self._trigger('introduceStateChange',self.INTRODUCE_STATE.ERROR, self._user.sid, message.sendingPeerId, message.receivingPeerId, message.reason);
 };
 
 /**


### PR DESCRIPTION
- Separate privilegedStateChange to introduceStateChange and getPeersStateChange for better user experience and internal state handling
- Add showAll flag to allow retrieval of all peer ids
