### PR TITLE
Handle safari not supporting createOffer with offerToReceiveAudio/Video

### DIFF
--- a/source/peer-handshake.js
+++ b/source/peer-handshake.js
@@ -47,6 +47,21 @@ Skylink.prototype._doOffer = function(targetMid, iceRestart) {
     }
   }
 
+
+  /* Safari does not support createOffer with (offerToReceiveAudio: 1)
+   * So the following patch is needed until it is fixed in AdapterJS.
+   * AdapterJS ticket : https://github.com/webrtc/adapter/issues/661
+   */
+  if(window.webrtcDetectedBrowser === 'safari' && webrtcDetectedVersion >= 11 
+      && AdapterJS.webrtcDetectedType !== 'plugin'){
+      if (offerConstraints.offerToReceiveAudio) {
+        pc.addTransceiver('audio');
+      }
+      if (offerConstraints.offerToReceiveVideo) {
+        pc.addTransceiver('video');
+      }
+  }
+
   log.debug([targetMid, null, null, 'Creating offer with config:'], offerConstraints);
 
   pc.endOfCandidates = false;
@@ -115,6 +130,21 @@ Skylink.prototype._doAnswer = function(targetMid) {
   // Add stream only at offer/answer end
   if (!self._hasMCU || targetMid === 'MCU') {
     self._addLocalMediaStreams(targetMid);
+  }
+
+
+  /* Safari does not support createOffer with (offerToReceiveAudio: 1)
+   * So the following patch is needed until it is fixed in AdapterJS.
+   * AdapterJS ticket : https://github.com/webrtc/adapter/issues/661
+   */
+  if(window.webrtcDetectedBrowser === 'safari' && webrtcDetectedVersion >= 11 
+      && AdapterJS.webrtcDetectedType !== 'plugin'){
+      if (answerConstraints.offerToReceiveAudio) {
+        pc.addTransceiver('audio');
+      }
+      if (answerConstraints.offerToReceiveVideo) {
+        pc.addTransceiver('video');
+      }
   }
 
   if (self._peerConnStatus[targetMid]) {


### PR DESCRIPTION
Safari doesn't support createOffer with (offerToReceiveAudio: 1, offerToReceiveVideo: 1) which is a barrier for Safari to connect with MCU because Safari won't do ICE gathering when createOffer is done above way. 
Until this is fixed in AdapterJS (https://github.com/webrtc/adapter/issues/661), patching SkylinkJS.