### PR TITLE
ESS-1061: Fixes for Firefox 59 not parsing the actual codecs.

### DIFF
--- a/source/stream-sdp.js
+++ b/source/stream-sdp.js
@@ -1316,10 +1316,6 @@ Skylink.prototype._getSDPCodecsSupport = function (targetMid, sessionDescription
   for (var i = 0; i < sdpLines.length; i++) {
     if (sdpLines[i].indexOf('m=') === 0) {
       mediaType = (sdpLines[i].split('m=')[1] || '').split(' ')[0];
-
-      if (['audio', 'video'].indexOf(mediaType) === -1) {
-        break;
-      }
       continue;
     }
 


### PR DESCRIPTION
**What is the purpose of the PR:**
This is to fix the parsing of the supported browser codecs for Firefox 59 due to the differing ordering.

See [ESS-1061](https://jira.temasys.com.sg/browse/ESS-1061) for more details.