### PR TITLE
ESS-1075: Add a flag to disable bundle policy in joinRoom() settings.

### DIFF
--- a/source/peer-handshake.js
+++ b/source/peer-handshake.js
@@ -196,6 +196,10 @@ Skylink.prototype._setLocalAndSendMessage = function(targetMid, _sessionDescript
   sessionDescription.sdp = self._handleSDPConnectionSettings(targetMid, sessionDescription, 'local');
   sessionDescription.sdp = self._removeSDPREMBPackets(targetMid, sessionDescription);
 
+  if (self._peerConnectionConfig.disableBundle) {
+    sessionDescription.sdp = sessionDescription.sdp.replace(/a=group:BUNDLE.*\r\n/gi, '');
+  }
+
   log.log([targetMid, 'RTCSessionDescription', sessionDescription.type,
     'Local session description updated ->'], sessionDescription.sdp);
 

--- a/source/room-connection.js
+++ b/source/room-connection.js
@@ -147,6 +147,8 @@
  *   generate and use when available.
  * - When not provided, its value is <code>AUTO</code>.
  *   [Rel: Skylink.PEER_CERTIFICATE]
+ * @param {String} [options.peerConnection.disableBundle=false] The flag if for each Peer connection instead of bundling all
+ *   media connections into 1 connection, should have all of them negotiated as different separate media connections.
  * @param {Boolean|JSON} [options.autoBandwidthAdjustment=false] <blockquote class="info">
  *   Note that this is an experimental feature which may be removed or changed in the future releases.
  *   This feature is also only available for non-MCU enabled Peer connections and Edge Peer connections.
@@ -691,7 +693,8 @@ Skylink.prototype._waitForOpenChannel = function(mediaOptions, joinRoomTimestamp
           bundlePolicy: self.BUNDLE_POLICY.BALANCED,
           rtcpMuxPolicy: self.RTCP_MUX_POLICY.REQUIRE,
           iceCandidatePoolSize: 0,
-          certificate: self.PEER_CERTIFICATE.AUTO
+          certificate: self.PEER_CERTIFICATE.AUTO,
+          disableBundle: false
         };
         self._bandwidthAdjuster = null;
 
@@ -791,6 +794,7 @@ Skylink.prototype._waitForOpenChannel = function(mediaOptions, joinRoomTimestamp
               }
             }
           }
+          self._peerConnectionConfig.disableBundle = mediaOptions.peerConnection.disableBundle === true;
         }
 
         if (mediaOptions.autoBandwidthAdjustment) {


### PR DESCRIPTION
**What is the purpose of this PR:**
Add a flag to disable bundling of media which is enabled by default to allow users to establish separate connections for each media track type.

See [ESS-1075 for more details](https://jira.temasys.com.sg/browse/ESS-1075).