### PR TITLE
ESS-1079: Clear datachannel instance for peer when it leaves the room.

### DIFF
--- a/source/data-channel.js
+++ b/source/data-channel.js
@@ -329,6 +329,9 @@ Skylink.prototype._closeDataChannel = function(peerId, channelProp) {
         }
       }
     }
+
+    delete self._dataChannels[peerId];
+
   } else {
     if (!self._dataChannels[peerId][channelProp]) {
       log.warn([peerId, 'RTCDataChannel', channelProp, 'Aborting closing Datachannel as it does not exists']);


### PR DESCRIPTION
**What is the purpose:**
This is to resolve the issue where in a scenario an user disconnects from the room using the `leaveRoom()` method, the datachannels references stored in the `_dataChannels` list is not cleared.

Based on the Web SDK logic which [avoids creating the "main" (messaging) datachannel again](https://github.com/Temasys/SkylinkJS/blob/0.6.29/source/peer-handshake.js#L44) when it already exists, it might be a problem when an user starts connecting to the room again with `joinRoom()`.

See [ESS-1079](https://jira.temasys.com.sg/browse/ESS-1079) for more details.