### PR TITLE
ESS-1073 Fixed _containsInList method to be private in documentation

### DIFF
--- a/source/room-init.js
+++ b/source/room-init.js
@@ -740,6 +740,7 @@ Skylink.prototype.init = function(_options, _callback) {
  * @method _containsInList
  * @for Skylink
  * @since 0.6.27
+ * @private
  */
 Skylink.prototype._containsInList = function (listName, value, defaultProperty) {
   var self = this;


### PR DESCRIPTION
**What is the purpose:**
This is to make private the _containsInList method. It is now hidden in the documentation.

See [ESS-1073](https://jira.temasys.com.sg/browse/ESS-1073) for details
