### PR TITLE
ESS-949: Improvement on socket buffer mechanism

### DIFF
--- a/source/peer-data.js
+++ b/source/peer-data.js
@@ -35,24 +35,26 @@
  */
 Skylink.prototype.setUserData = function(userData) {
   var self = this;
-  var updatedUserData = '';
+  var userId = self._user && self._user.sid;
 
-  if (!(typeof userData === 'undefined' || userData === null)) {
-    updatedUserData = userData;
-  }
-
-  this._userData = updatedUserData;
+  self._userData = !(typeof userData === 'undefined' || userData === null) ? userData : '';
+  log.debug('Updated custom user data -> ', self._userData);
 
   if (self._inRoom) {
-    log.log('Updated userData -> ', updatedUserData);
     self._sendChannelMessage({
       type: self._SIG_MESSAGE_TYPE.UPDATE_USER,
-      mid: self._user.sid,
+      mid: userId,
       rid: self._room.id,
-      userData: updatedUserData,
+      userData: self._userData,
       stamp: (new Date()).getTime()
+
+    }, function (error) {
+      if (error) {
+        return;
+      }
+
+      self._trigger('peerUpdated', userId, self.getPeerInfo(), true);
     });
-    self._trigger('peerUpdated', self._user.sid, self.getPeerInfo(), true);
   } else {
     log.warn('User is not in the room. Broadcast of updated information will be dropped');
   }

--- a/source/room-connection.js
+++ b/source/room-connection.js
@@ -601,18 +601,31 @@ Skylink.prototype.leaveRoom = function(stopMediaOptions, callback) {
  * @since 0.5.0
  */
 Skylink.prototype.lockRoom = function() {
-  if (!(this._user && this._user.sid)) {
+  var self = this;
+  var userId = self._user && self._user.sid;
+  var room = self._selectedRoom;
+
+  if (!userId) {
+    log.warn([null, 'Room', null, 'Unable to lock room as user is not in the room']);
     return;
   }
-  log.log('Update to isRoomLocked status ->', true);
-  this._sendChannelMessage({
-    type: this._SIG_MESSAGE_TYPE.ROOM_LOCK,
-    mid: this._user.sid,
-    rid: this._room.id,
+
+  log.debug([userId, 'Room', room, 'Update to lock status ->'], true);
+
+  self._sendChannelMessage({
+    type: self._SIG_MESSAGE_TYPE.ROOM_LOCK,
+    mid: userId,
+    rid: self._room.id,
     lock: true
+  }, function (error) {
+    if (error) {
+      log.error([userId, 'Room', room, 'Failed locking the room ->'], error);
+      return;
+    }
+
+    self._roomLocked = true;
+    self._trigger('roomLock', true, userId, self.getPeerInfo(), true);
   });
-  this._roomLocked = true;
-  this._trigger('roomLock', true, this._user.sid, this.getPeerInfo(), true);
 };
 
 /**
@@ -635,18 +648,31 @@ Skylink.prototype.lockRoom = function() {
  * @since 0.5.0
  */
 Skylink.prototype.unlockRoom = function() {
-  if (!(this._user && this._user.sid)) {
+  var self = this;
+  var userId = self._user && self._user.sid;
+  var room = self._selectedRoom;
+
+  if (!userId) {
+    log.warn([null, 'Room', null, 'Unable to unlock room as user is not in the room']);
     return;
   }
-  log.log('Update to isRoomLocked status ->', false);
-  this._sendChannelMessage({
-    type: this._SIG_MESSAGE_TYPE.ROOM_LOCK,
-    mid: this._user.sid,
-    rid: this._room.id,
+
+  log.debug([userId, 'Room', room, 'Update to lock status ->'], false);
+
+  self._sendChannelMessage({
+    type: self._SIG_MESSAGE_TYPE.ROOM_LOCK,
+    mid: userId,
+    rid: self._room.id,
     lock: false
+  }, function (error) {
+    if (error) {
+      log.error([userId, 'Room', room, 'Failed unlocking the room ->'], error);
+      return;
+    }
+
+    self._roomLocked = false;
+    self._trigger('roomLock', false, userId, self.getPeerInfo(), true);
   });
-  this._roomLocked = false;
-  this._trigger('roomLock', false, this._user.sid, this.getPeerInfo(), true);
 };
 
 /**

--- a/source/socket-channel.js
+++ b/source/socket-channel.js
@@ -67,8 +67,9 @@ Skylink.prototype._sendChannelMessageQueue = function() {
     // Then start sending normal lane messages.
     // Checks if the first message is a targeted message, in which it will send the targeted message individually first.
     // If the first message is a grouped type of message, queue the rest of the grouped message to be able to do bulk send.
-    } else if (self._socketMessageQueue.normal.length) {
-      if (self._GROUP_MESSAGE_LIST.indexOf(self._socketMessageQueue.normal[0][0].type) === -1) {
+    } else if (self._socketMessageQueue.normal.length || Object.keys(self._socketMessageQueue.status).length > 0) {
+      // In some scenarios where the normal queue is empty, the status messages may be updated.
+      if (self._socketMessageQueue.normal.length && self._GROUP_MESSAGE_LIST.indexOf(self._socketMessageQueue.normal[0][0].type) === -1) {
         message = self._socketMessageQueue.normal.splice(0, 1)[0];
 
       } else {
@@ -82,7 +83,7 @@ Skylink.prototype._sendChannelMessageQueue = function() {
             // Check if the status message is outdated before discarding it.
             if (self._peerMessagesStamps.self[type] < statusMessages[type][0].stamp) {
               self._peerMessagesStamps.self[type] = statusMessages[type][0].stamp;
-              groupedBatch.push(statusMessages[type][0]);
+              groupedBatch.push(JSON.stringify(statusMessages[type][0]));
               groupedCallbacks.push(statusMessages[type][1])
             }
           }

--- a/source/socket-channel.js
+++ b/source/socket-channel.js
@@ -86,7 +86,9 @@ Skylink.prototype._sendChannelMessageQueue = function() {
     }, 0);
 
   // Send the targeted messages second if it is the first item in the normal queue.
-  } else if (self._socketMessageQueue.normal.length && self._socketMessageQueue.normal[0][0].target) {
+  // Make sure there are no status messages in the current queue first since status should be sent first.
+  } else if (self._socketMessageQueue.normal.length && self._socketMessageQueue.normal[0][0].target &&
+    !Object.keys(self._socketMessageQueue.status).length) {
     self._socketMessageInterval = setTimeout(function () {
       var queueItem = self._socketMessageQueue.normal.splice(0, 1)[0];
       var message = queueItem[0];

--- a/source/template/header.js
+++ b/source/template/header.js
@@ -393,7 +393,7 @@ function Skylink() {
   this._onceEvents = {};
 
   /**
-   * Stores the timestamps data used for throttling.
+   * Stores the last active timestamps for throttling or intervals.
    * @attribute _timestamp
    * @type JSON
    * @private
@@ -419,26 +419,39 @@ function Skylink() {
   this._socketSession = {};
 
   /**
-   * Stores the queued socket messages.
-   * This is to prevent too many sent over less than a second interval that might cause dropped messages
-   *   or jams to the Signaling connection.
+   * Stores the buffered socket messages for sending to the signaling server.
    * @attribute _socketMessageQueue
-   * @type Array
+   * @type JSON
    * @private
    * @for Skylink
-   * @since 0.5.8
+   * @since 0.6.31
    */
-  this._socketMessageQueue = [];
+  this._socketMessageQueue = {
+    priority: [],
+    normal: [],
+    status: {}
+  };
 
   /**
-   * Stores the <code>setTimeout</code> to sent queued socket messages.
+   * Stores the timeout interval for sending buffered socket messages.
    * @attribute _socketMessageTimeout
-   * @type Object
+   * @type Number
    * @private
    * @for Skylink
-   * @since 0.5.8
+   * @since 0.6.31
    */
   this._socketMessageTimeout = null;
+
+  /**
+   * Stores the socket connection latency in ms.
+   * For safer checks, make the latency more than 150ms.
+   * @attribute _socketMessageLatency
+   * @type Number
+   * @private
+   * @for Skylink
+   * @since 0.6.31
+   */
+  this._socketMessageLatency = 150;
 
   /**
    * Stores the list of socket ports to use to connect to the Signaling.
@@ -594,7 +607,7 @@ function Skylink() {
   this._room = null;
 
   /**
-   * Stores the list of Peer messages timestamp.
+   * Stores the list of broadcasted user status messages timestamps to prevent updating outdated message statuses.
    * @attribute _peerMessagesStamps
    * @type JSON
    * @private

--- a/source/template/header.js
+++ b/source/template/header.js
@@ -434,35 +434,23 @@ function Skylink() {
 
   /**
    * Stores the timeout interval for sending buffered socket messages.
-   * @attribute _socketMessageTimeout
+   * @attribute _socketMessageInterval
    * @type Number
    * @private
    * @for Skylink
    * @since 0.6.31
    */
-  this._socketMessageTimeout = null;
+  this._socketMessageInterval = null;
 
   /**
    * Stores the socket connection latency in ms.
-   * For safer checks, make the latency more than 150ms.
-   * @attribute _socketMessageLatency
+   * @attribute _socketLatency
    * @type Number
    * @private
    * @for Skylink
    * @since 0.6.31
    */
-  this._socketMessageLatency = 150;
-
-  /**
-   * Stores the last sent socket message type.
-   * This helps us determine if we should append timeout interval or not.
-   * @attribute _socketMessageType
-   * @type Number
-   * @private
-   * @for Skylink
-   * @since 0.6.31
-   */
-  this._socketMessageType = 150;
+  this._socketLatency = null;
 
   /**
    * Stores the list of socket ports to use to connect to the Signaling.

--- a/source/template/header.js
+++ b/source/template/header.js
@@ -454,6 +454,17 @@ function Skylink() {
   this._socketMessageLatency = 150;
 
   /**
+   * Stores the last sent socket message type.
+   * This helps us determine if we should append timeout interval or not.
+   * @attribute _socketMessageType
+   * @type Number
+   * @private
+   * @for Skylink
+   * @since 0.6.31
+   */
+  this._socketMessageType = 150;
+
+  /**
    * Stores the list of socket ports to use to connect to the Signaling.
    * These ports are defined by default which is commonly used currently by the Signaling.
    * Should re-evaluate this sometime.


### PR DESCRIPTION
**What is the purpose of this PR:**
The purpose is to improve the current socket buffer mechanism and to fix the "redirect" message being received from the signaling server because the current socket buffer mechanism does not account for it.

Read [source/socket-channel.js file `_sendChannelMessageQueue()` function](https://github.com/Temasys/SkylinkJS/blob/0.6.x/ESS-949-socket-message-buffer/source/socket-channel.js) to review the logic better.

The message rates are as follows:
- `1000` ms for broadcasted messages.
- `100` ms for "private" messages.

**Previous logic:**
Let's call "INT" as the time apart from the previous last sent message.

1. Send the message if it is not a rated message.
2. Send the message if it is a rated message and INT is more than the required rate.
3. Buffer the message if it is a rated message and INT is less than the required rate.
4. When the timing is right, send a "group" message with a maximum batch of 16 messages. After that, filter for any outdated status messages within that batch.

The downsides of the current logic is that:
1. It does not account for "private" messages.
2. It is not very efficient in it's batching, at times it could send a broadcasted rated message at 1 at a go, when it could have sent 16 at a go.
3. If the batch contains all the list of outdated status messages, it would send a "group" message with an empty list.
4. It groups "roomLockEvent" messages and that event should be instantaneous instead of being grouped. 

**Proposed logic:**
The proposed logic aims to have several lanes.
- Priority lane: For non-rated messages and "roomLockEvent" message.
- Normal lane: For "private" messages and the other broadcasted rated messages.
- Status lane: For status (e.g. "updateUserEvent") messages.

Having a priority lane allows us to add intervals of maybe about `20` ms in the future to prevent overwhelming servers. The formula for rate (call it as "RTE") would be: `message_rate + latency`. Let's call "INT" as the time apart from the previous last sent message as before.

1. Send priority lane messages with `0` ms interval. If it is a "roomLockEvent" message and the "INT" is less than the "RTE", drop the message if not send it directly.
2. Send status lane messages with "RTE" ms interval. Group it along with the normal lane broadcasted rated messages to become a "group" message with 16 messages batch.
3. Send normal lane messages with "RTE" ms interval depending on which is the first message in the lane. If the first item is "private" message, send it individually. Else, send it together to form a "group" message with 16 messages batch.

The idea is to quicken the sending of the messages.

-----

Additionally, this PR has solved a problem whereby the `incomingMessage`, `roomLock` and `peerUpdated` event is triggered despite the message because queued or dropped. These events would now only trigger after the messages are actually sent. And if the "roomLockEvent" message was dropped, the `roomLock` event will not be triggered.

See [ESS-949](https://jira.temasys.com.sg/browse/ESS-949) for more details.