### PR TITLE
ESS-1086: Fixes for Firefox 58 not returning ICE candidate pair stats from getConnectionStatus()

### DIFF
--- a/source/peer-connection.js
+++ b/source/peer-connection.js
@@ -851,7 +851,7 @@ Skylink.prototype._retrieveStats = function (peerId, callback, beSilentOnLogs, i
       output.selectedCandidate.remote.candidateType = remoteCanItem.candidateType;
 
     // Firefox
-    } else if (item.type === 'candidatepair' && item.state === 'succeeded' && item.nominated) {
+    } else if (['candidate-pair', 'candidatepair'].indexOf(item.type) > -1 && item.state === 'succeeded' && item.nominated) {
       output.selectedCandidate.writable = item.writable;
       output.selectedCandidate.readable = item.readable;
 


### PR DESCRIPTION
**Purpose of this PR:**
The purpose is to fix the issue where Firefox 58+ is not returning the ICE candidate pair information from `getConnectionStatus()`.

See [ESS-1086](https://jira.temasys.com.sg/browse/ESS-1086) for more details.