### PR TITLE
ESS-502: Pre-configured list of max bandwidth sets constant

### DIFF
--- a/source/constants.js
+++ b/source/constants.js
@@ -1464,3 +1464,25 @@ Skylink.prototype._GROUP_MESSAGE_LIST = [
   Skylink.prototype._SIG_MESSAGE_TYPE.PUBLIC_MESSAGE
 ];
 
+/**
+ * The options available for video and audio bitrates quality.
+ * @attribute VIDEO_QUALITY
+ * @param {String} HD <small>Value <code>{ video: 3200, audio: 80 }</code></small>
+ *   The value of the state when Datachannel is attempting to establish a connection.
+ * @param {String} HQ <small>Value <code>{ video: 1200, audio: 50 }</code></small>
+ *   The value of the state when Datachannel has established a connection.
+ * @param {String} SQ <small>Value <code>{ video: 800, audio: 30 }</code></small>
+ *   The value of the state when Datachannel connection is closing.
+ * @param {String} LQ <small>Value <code>{ video: 500, audio: 20 }</code></small>
+ *   The value of the state when Datachannel connection has closed.
+ * @type JSON
+ * @readOnly
+ * @for Skylink
+ * @since 0.6.32
+ */
+Skylink.prototype.VIDEO_QUALITY = {
+  HD: { video: 3200, audio: 150 },
+  HQ: { video: 1200, audio: 80 },
+  SQ: { video: 800, audio: 30 },
+  LQ: { video: 400, audio: 20 }
+};

--- a/source/constants.js
+++ b/source/constants.js
@@ -1465,16 +1465,16 @@ Skylink.prototype._GROUP_MESSAGE_LIST = [
 ];
 
 /**
- * The options available for video and audio bitrates quality.
+ * The options available for video and audio bitrates (kbps) quality.
  * @attribute VIDEO_QUALITY
- * @param {String} HD <small>Value <code>{ video: 3200, audio: 80 }</code></small>
- *   The value of option to prefer high definition video and audio bitrates
- * @param {String} HQ <small>Value <code>{ video: 1200, audio: 50 }</code></small>
- *   The value of option to prefer high quality video and audio bitrates
- * @param {String} SQ <small>Value <code>{ video: 800, audio: 30 }</code></small>
- *   The value of option to prefer standard quality video and audio bitrates
- * @param {String} LQ <small>Value <code>{ video: 500, audio: 20 }</code></small>
- *   The value of option to prefer low quality video and audio bitrates
+ * @param {JSON} HD <small>Value <code>{ video: 3200, audio: 80 }</code></small>
+ *   The value of option to prefer high definition video and audio bitrates.
+ * @param {JSON} HQ <small>Value <code>{ video: 1200, audio: 50 }</code></small>
+ *   The value of option to prefer high quality video and audio bitrates.
+ * @param {JSON} SQ <small>Value <code>{ video: 800, audio: 30 }</code></small>
+ *   The value of option to prefer standard quality video and audio bitrates.
+ * @param {JSON} LQ <small>Value <code>{ video: 500, audio: 20 }</code></small>
+ *   The value of option to prefer low quality video and audio bitrates.
  * @type JSON
  * @readOnly
  * @for Skylink

--- a/source/constants.js
+++ b/source/constants.js
@@ -1468,13 +1468,13 @@ Skylink.prototype._GROUP_MESSAGE_LIST = [
  * The options available for video and audio bitrates quality.
  * @attribute VIDEO_QUALITY
  * @param {String} HD <small>Value <code>{ video: 3200, audio: 80 }</code></small>
- *   The value of the state when Datachannel is attempting to establish a connection.
+ *   The value of option to prefer high definition video and audio bitrates
  * @param {String} HQ <small>Value <code>{ video: 1200, audio: 50 }</code></small>
- *   The value of the state when Datachannel has established a connection.
+ *   The value of option to prefer high quality video and audio bitrates
  * @param {String} SQ <small>Value <code>{ video: 800, audio: 30 }</code></small>
- *   The value of the state when Datachannel connection is closing.
+ *   The value of option to prefer standard quality video and audio bitrates
  * @param {String} LQ <small>Value <code>{ video: 500, audio: 20 }</code></small>
- *   The value of the state when Datachannel connection has closed.
+ *   The value of option to prefer low quality video and audio bitrates
  * @type JSON
  * @readOnly
  * @for Skylink

--- a/source/room-connection.js
+++ b/source/room-connection.js
@@ -43,7 +43,8 @@
  * @param {JSON} [options.bandwidth] <blockquote class="info">Note that this is currently not supported
  *   with Firefox browsers versions 48 and below as noted in an existing
  *   <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=976521#c21">bugzilla ticket here</a>.</blockquote>
- *   The configuration to set the maximum streaming bandwidth to send to Peers.
+ *   The configuration to set the maximum streaming bandwidth to send to Peers. You can also use the preconfigured 
+ *   constant <a href="#attr_VIDEO_QUALITY"><code>VIDEO_QUALITY</code></a> for recommended values.
  * @param {Number} [options.bandwidth.audio] The maximum audio streaming bandwidth sent to Peers in kbps.
  *   <small>Recommended values are <code>50</code> to <code>200</code>. <code>50</code> is sufficient enough for
  *   an audio call. The higher you go if you want clearer audio and to be able to hear music streaming.</small>
@@ -229,6 +230,14 @@
  *   }, function (error, success) {
  *     if (error) return;
  *     console.log("User connected with correct user data?", success.peerInfo.userData.username === data.username);
+ *   });
+ * 
+ *   // Example 6: Connecting to "testxx" Room with a pre-configured bandwidth set
+ *   skylinkDemo.joinRoom("testxx", {
+ *     bandwidth: skylinkDemo.VIDEO_QUALITY.HD
+ *   }, function (error, success) {
+ *     if (error) return;
+ *     console.log("User connected with bandwidth quality HD");
  *   });
  * @trigger <ol class="desc-seq">
  *   <li>If User is in a Room: <ol>


### PR DESCRIPTION
**Purpose of this PR**

To make a `constant` that would list a list of bandwidth sets that would produce the required definition quality.

Example:

```
Skylink.prototype.VIDEO_QUALITY = {
  HD: { video: 3200, audio: 80 },
  HQ: { video: 1200, audio: 50 },
  SQ: { video: 800, audio: 30 },
  LQ: { video: 500, audio: 20 }
}
```
_Birates are in kbps_

---------------


Also, to update the documentation of `joinRoom fn` to demonstrate the usage of `VIDEO_QUALITY` constant with `options.bandwidth`.
