### PR TITLE
ESS-1038: Add custom headers to XHR and socket to send to signalling

### DIFF
--- a/source/room-init.js
+++ b/source/room-init.js
@@ -833,6 +833,13 @@ Skylink.prototype._requestServerInfo = function(method, url, callback, params) {
 
     try {
       xhr.open(method, url, true);
+
+      // ESS-1038: Adding custom headers to signaling
+      if(!self._socketUseXDR) {
+        xhr.setRequestHeader('Skylink_SDK_version', self.VERSION);
+        xhr.setRequestHeader('Skylink_SDK_type', 'WEB_SDK');
+      }
+
       if (params) {
         xhr.setContentType('application/json;charset=UTF-8');
         xhr.send(JSON.stringify(params));

--- a/source/socket-channel.js
+++ b/source/socket-channel.js
@@ -217,7 +217,11 @@ Skylink.prototype._createSocket = function (type, joinRoomTimestamp) {
     reconnectionAttempts: 2,
     reconnectionDelayMax: 5000,
     reconnectionDelay: 1000,
-    transports: ['websocket']
+    transports: ['websocket'],
+    query: { // ESS-1038: Adding custom headers to signaling
+      Skylink_SDK_type: 'WEB_SDK',
+      Skylink_SDK_version: self.VERSION
+    }
   };
   var ports = self._initOptions.socketServer && typeof self._initOptions.socketServer === 'object' && Array.isArray(self._initOptions.socketServer.ports) &&
     self._initOptions.socketServer.ports.length > 0 ? self._initOptions.socketServer.ports : self._socketPorts[self._signalingServerProtocol];


### PR DESCRIPTION
**Purpose of this PR**

For the mobile SDKs, when communicating with API and Signaling servers, we should add in the Headers the identity of our SDKs, so that all messages will have the identity of the sending SDK. 

We could have 2 headers: (POST)
Skylink_SDK_type
Skylink_SDK_version

Skylink_SDK_type would specific the type of Skylink SDK, ie. "Android Java", "IOS Objective C", "Android Kotlin", "IOS Swift"etc.

Skylink_SDK_version would provide the version string of the SDK, e.g. "0.11.0", "1.2.0", etc.