### PR TITLE
ESS-1172: Error on remote description when using Firefox 61

### DIFF
--- a/source/socket-message.js
+++ b/source/socket-message.js
@@ -1729,22 +1729,6 @@ Skylink.prototype._answerHandler = function(message) {
 
   self._parseSDPMediaStreamIDs(targetMid, answer);
 
-  function changeSDPFormat(sdp){
-    if(sdp.indexOf("m=video")>sdp.indexOf("m=audio")){
-      var sIndex = sdp.indexOf("m=video");
-      var eIndex = sdp.lastIndexOf("m=");
-      var mVideoLineStr = sdp.substring(sIndex,eIndex)+"m=audio";
-      sdp = sdp.replace(sdp.substring(sIndex, eIndex), "");
-      sdp = sdp.replace("m=audio", mVideoLineStr);
-    }
-    return sdp;
-  }
-
-  if (self._hasMCU && targetMid !== 'MCU'
-    && AdapterJS.webrtcDetectedBrowser === 'firefox'
-    && AdapterJS.webrtcDetectedVersion >= 59) {
-    answer.sdp = changeSDPFormat(answer.sdp);
-  }
 
   var onSuccessCbFn = function() {
     log.debug([targetMid, null, message.type, 'Remote description set']);


### PR DESCRIPTION
**Purpose of this PR**

To fix FF60 C-line issue - a `fn::changeSDPFormat` was added as a patch. This needs to be removed as  it is breaking FF61.