### PR TITLE
Amend documentation: Explicit specification of enableAudio flag as tr…

### DIFF
--- a/source/stream-media.js
+++ b/source/stream-media.js
@@ -957,7 +957,7 @@ Skylink.prototype.disableVideo = function() {
  *   <small>Object signature is the screensharing Stream object.</small>
  * @example
  *   // Example 1: Share screen with audio
- *   skylinkDemo.shareScreen(function (error, success) {
+ *   skylinkDemo.shareScreen(true, function (error, success) {
  *     if (error) return;
  *     attachMediaStream(document.getElementById("my-screen"), success);
  *   });


### PR DESCRIPTION
**Purpose of this PR**

The [first example](https://cdn.temasys.io/skylink/skylinkjs/latest/doc/classes/Skylink.html#method_shareScreen) for `shareScreen` function is intended to convey sharing a screen with audio enabled. But the method call is missing the first param of `enableAudio` whose default value is `false`. 

This PR updates the method call to send a first parameter boolean `true` to convey that the caller of the method has to explicitly set `enableAudio` to true/object.