### PR TITLE
Remove user-agent check for FF for deviceId for video sources to enable multiple camera streams

### DIFF
--- a/source/stream-media.js
+++ b/source/stream-media.js
@@ -1776,8 +1776,7 @@ Skylink.prototype._parseStreamSettings = function(options) {
         settings.getUserMediaSettings.video.optional = clone(options.video.optional);
       }
 
-      if (options.video.deviceId && typeof options.video.deviceId === 'string' &&
-        AdapterJS.webrtcDetectedBrowser !== 'firefox') {
+      if (options.video.deviceId && typeof options.video.deviceId === 'string') {
         settings.settings.video.deviceId = options.video.deviceId;
         settings.getUserMediaSettings.video.deviceId = options.useExactConstraints ?
           { exact: options.video.deviceId } : { ideal: options.video.deviceId };


### PR DESCRIPTION
**Purpose of this PR**

Firefox supports `deviceId` and exact parameter for `getUserMedia` constraints. Hence this PR removes the useragent for FF check that prevents it from setting the constraints when `sendStream` is called with a different `deviceId`. 

This enables switching of camera's in the peer's machine if he as rear facing camera or webcams attached (In Firefox). 

Please see [JIRA ticket](https://jira.temasys.com.sg/browse/ESS-1174) for more info.



