### PR TITLE
AJS-307: IE Edge not connecting peers because of EndOfCandidate message timing issue

### DIFF
--- a/source/ice-candidate.js
+++ b/source/ice-candidate.js
@@ -112,15 +112,18 @@ Skylink.prototype._onIceCandidate = function(targetMid, candidate) {
         rid: self._room.id
       });
     } else if (self._gatheredCandidates[targetMid]) {
-      self._sendChannelMessage({
-        type: self._SIG_MESSAGE_TYPE.END_OF_CANDIDATES,
-        noOfExpectedCandidates: self._gatheredCandidates[targetMid].sending.srflx.length +
-          self._gatheredCandidates[targetMid].sending.host.length +
-          self._gatheredCandidates[targetMid].sending.relay.length,
-        mid: self._user.sid,
-        target: targetMid,
-        rid: self._room.id
-      });
+      var sendEndOfCandidates = function() {
+        self._sendChannelMessage({
+          type: self._SIG_MESSAGE_TYPE.END_OF_CANDIDATES,
+          noOfExpectedCandidates: self._gatheredCandidates[targetMid].sending.srflx.length +
+            self._gatheredCandidates[targetMid].sending.host.length +
+            self._gatheredCandidates[targetMid].sending.relay.length,
+          mid: self._user.sid,
+          target: targetMid,
+          rid: self._room.id
+        });
+      };
+      setTimeout(sendEndOfCandidates, 6000);
     }
   }
 };


### PR DESCRIPTION
**Purpose of this PR**

Looks like the `EndOfCandidates` message is sent before gathering all candidates and this causes issue with connectivity in Edge. Hence, adding a patch code for `setTimeout` of 6000ms to enforce that `EndOfCandidate` message is sent as the last message to Edge.
