### PR TITLE
ESS-1262 : Ghost whitespace - random Greek Characters remove

### DIFF
--- a/source/room-init.js
+++ b/source/room-init.js
@@ -1097,8 +1097,8 @@ Skylink.prototype._initSelectedRoom = function(room, callback) {
   options.iceServer = options.iceServer ? options.iceServer.urls : null;
 
   if(options.defaultRoom!==room){
-    options.defaultRoom = room;
-  }
+    options.defaultRoom = room;
+  }
 
   self.init(options, function (error, success) {
     self._initOptions.defaultRoom = defaultRoom;


### PR DESCRIPTION
The compiled skylink js had some weird characters. Screenshot is attached in the ticket ESS-1262