### PR TITLE
ESS-1211: RTMP Changes and New MCU Support Changes 

### DIFF
--- a/demo/app/index.html
+++ b/demo/app/index.html
@@ -75,7 +75,7 @@
               </table>
             </div>
           </div>
-          <div id="presence_panel" class="panel panel-default">
+          <div id="presence_panel" class="panel panel-default hidden">
             <div class="panel-heading">Connected Peers</div>
             <div class="panel-body">
               <table id="presence_list" class="table">

--- a/demo/app/index.html
+++ b/demo/app/index.html
@@ -170,6 +170,11 @@
                     <span class="glyphicon glyphicon-log-out"></span>
                     <b>Message</b>
                   </button>
+
+                  <button id="live_streaming_btn" type="button" title="Start a live stream" class="btn btn-default">
+                    <span class="glyphicon glyphicon-bullhorn"></span>
+                    <b>Live Streaming</b>
+                  </button>
                 </span>
               </div>
             </div>

--- a/demo/app/index.html
+++ b/demo/app/index.html
@@ -171,9 +171,9 @@
                     <b>Message</b>
                   </button>
 
-                  <button id="live_streaming_btn" type="button" title="Start a live stream" class="btn btn-default">
+                  <button data-isstreaming="false" id="live_streaming_btn" type="button" title="Start a live stream" class="btn btn-default">
                     <span class="glyphicon glyphicon-bullhorn"></span>
-                    <b>Live Streaming</b>
+                    <b class="text">Live Streaming</b>
                   </button>
                 </span>
               </div>

--- a/demo/app/js/main.js
+++ b/demo/app/js/main.js
@@ -975,7 +975,7 @@ $(document).ready(function() {
     var $streamingButton = $(this);
     var isStreaming = $(this).data('isstreaming');
     if (isStreaming === false) {
-      var rtmpUrl = prompt('Enter your livestream link below');
+      var rtmpUrl = 'rtmp://a.rtmp.youtube.com/live2/q6xg-s0kv-q98q-5kbm'; //prompt('Enter your livestream link below');
       var streamId = Demo.Skylink._streams.userMedia.id;
       Demo.Skylink.startRTMPSession(streamId, rtmpUrl, function(rtmpId) {
         $streamingButton.data('isstreaming', true);

--- a/demo/app/js/main.js
+++ b/demo/app/js/main.js
@@ -972,11 +972,25 @@ $(document).ready(function() {
   });
 
   $('#live_streaming_btn').click(function() {
-    var rtmpUrl = prompt('Enter your livestream link below');
-    var streamId = Demo.Skylink._streams.userMedia.id;
-    Demo.Skylink.startRTMPSession(streamId, rtmpUrl, function(response) {
-      console.log(response);
-    });
+    var $streamingButton = $(this);
+    var isStreaming = $(this).data('isstreaming');
+    if (isStreaming === false) {
+      var rtmpUrl = prompt('Enter your livestream link below');
+      var streamId = Demo.Skylink._streams.userMedia.id;
+      Demo.Skylink.startRTMPSession(streamId, rtmpUrl, function(rtmpId) {
+        $streamingButton.data('isstreaming', true);
+        $streamingButton.data('rtmpid', rtmpId);
+        $streamingButton.find('.text').text('Stop Streaming');
+      });
+    } else {
+      var rtmpId = $streamingButton.data('rtmpid');
+      Demo.Skylink.stopRTMPSession(rtmpId, function() {
+        $streamingButton.data('isstreaming', false);
+        $streamingButton.data('rtmpid', null);
+        $streamingButton.find('.text').text('Live Streaming');
+      });
+    }
+
   });
 
   window.selectTargetPeer = function(dom) {

--- a/demo/app/js/main.js
+++ b/demo/app/js/main.js
@@ -593,7 +593,7 @@ Demo.Skylink.on('recordingState', function(state, recordingId, url, error) {
       break;
     case Demo.Skylink.RECORDING_STATE.STOP:
       $('#recording_' + recordingId + '_state_icon').attr('class', 'glyphicon glyphicon-refresh');
-      $('#recording_' + recordingId + '_state').html('STOPPED / PROCESSING VIDEO');
+      $('#recording_' + recordingId + '_state').html('RECORDING STOPPED');
       $('#recording_' + recordingId + '_error').html('');
       break;
     case Demo.Skylink.RECORDING_STATE.LINK:

--- a/demo/app/js/main.js
+++ b/demo/app/js/main.js
@@ -971,6 +971,14 @@ $(document).ready(function() {
     });
   });
 
+  $('#live_streaming_btn').click(function() {
+    var rtmpUrl = prompt('Enter your livestream link below');
+    var streamId = Demo.Skylink._streams.userMedia.id;
+    Demo.Skylink.startRTMPSession(streamId, rtmpUrl, function(response) {
+      console.log(response);
+    });
+  });
+
   window.selectTargetPeer = function(dom) {
     var peerId = $(dom).attr('target');
     var panelDom = $('#selected_users_panel');

--- a/source/constants.js
+++ b/source/constants.js
@@ -1443,6 +1443,9 @@ Skylink.prototype._SIG_MESSAGE_TYPE = {
   APPROACH: 'approach',
   START_RECORDING: 'startRecordingRoom',
   STOP_RECORDING: 'stopRecordingRoom',
+  START_RTMP: 'startRTMP',
+  STOP_RTMP: 'stopRTMP',
+  RTMP: 'rtmpEvent',
   RECORDING: 'recordingEvent',
   END_OF_CANDIDATES: 'endOfCandidates'
 };

--- a/source/constants.js
+++ b/source/constants.js
@@ -1481,7 +1481,7 @@ Skylink.prototype._GROUP_MESSAGE_LIST = [
  */
 Skylink.prototype.STATS_API_VERSION = '1.1';
 
-/*
+/**
  * The options available for video and audio bitrates (kbps) quality.
  * @attribute VIDEO_QUALITY
  * @param {JSON} HD <small>Value <code>{ video: 3200, audio: 80 }</code></small>
@@ -1502,4 +1502,25 @@ Skylink.prototype.VIDEO_QUALITY = {
   HQ: { video: 1200, audio: 80 },
   SQ: { video: 800, audio: 30 },
   LQ: { video: 400, audio: 20 }
+};
+
+/**
+ * The list of RTMP states.
+ * @attribute RTMP_STATE
+ * @param {Number} START <small>Value <code>0</code></small>
+ *   The value of the state when live streaming session has started.
+ * @param {Number} STOP <small>Value <code>1</code></small>
+ *   The value of the state when live streaming session has stopped.<br>
+ *   <small>At this stage, the recorded videos will go through the mixin server to compile the videos.</small>
+ * @param {Number} ERROR <small>Value <code>-1</code></small>
+ *   The value of the state state when live streaming session has errors.
+ * @type JSON
+ * @beta
+ * @for Skylink
+ * @since 0.6.34
+ */
+Skylink.prototype.RTMP_STATE = {
+  START: 0,
+  STOP: 1,
+  ERROR: -1
 };

--- a/source/data-transfer.js
+++ b/source/data-transfer.js
@@ -734,7 +734,7 @@ Skylink.prototype.sendP2PMessage = function(message, targetPeerId) {
   for (var i = 0; i < listOfPeers.length; i++) {
     var peerId = listOfPeers[i];
 
-    if (!this._dataChannels[peerId]) {
+    if (!this._hasMCU && !this._dataChannels[peerId]) {
       log.error([peerId, 'RTCDataChannel', null, 'Dropping of sending message to Peer as ' +
         'Datachannel connection does not exists']);
       listOfPeers.splice(i, 1);

--- a/source/data-transfer.js
+++ b/source/data-transfer.js
@@ -1583,9 +1583,9 @@ Skylink.prototype._startDataTransfer = function(data, timeout, targetPeerId, sen
   }
 
   // Remove MCU Peer as list of Peers
-  if (listOfPeers.indexOf('MCU') > -1) {
-    listOfPeers.splice(listOfPeers.indexOf('MCU'), 1);
-  }
+  // if (listOfPeers.indexOf('MCU') > -1) {
+  //   listOfPeers.splice(listOfPeers.indexOf('MCU'), 1);
+  // }
 
   // Function that returns the error emitted before data transfer has started
   var emitErrorBeforeDataTransferFn = function (error) {

--- a/source/peer-connection.js
+++ b/source/peer-connection.js
@@ -1875,22 +1875,22 @@ Skylink.prototype._createPeerConnection = function(targetMid, isScreenSharing, c
     //   return text;
     // }
     // self.peerStreamTable[stream.id] = makeFackUserId();
-    var video = document.createElement('video');
-    video.autoplay = true;
-    video.id = stream.id;
-    video.peerId = self.streamIdPeerIdMap[stream.id];
-    window.document.body.append(video);
-    self.videoRenderers[stream.id] = attachMediaStream(video, stream);
+    // var video = document.createElement('video');
+    // video.autoplay = true;
+    // video.id = stream.id;
+    // video.peerId = self.streamIdPeerIdMap[stream.id];
+    // window.document.body.append(video);
+    // self.videoRenderers[stream.id] = attachMediaStream(video, stream);
     // End of MCU test
 
 
-    if (targetMid === 'MCU') {
-      log.warn([targetMid, 'MediaStream', pc.remoteStreamId, 'Ignoring received remote stream from MCU ->'], stream);
-      return;
-    } else if (!self._sdpSettings.direction.audio.receive && !self._sdpSettings.direction.video.receive) {
-      log.warn([targetMid, 'MediaStream', pc.remoteStreamId, 'Ignoring received empty remote stream ->'], stream);
-      return;
-    }
+    // if (targetMid === 'MCU') {
+    //   log.warn([targetMid, 'MediaStream', pc.remoteStreamId, 'Ignoring received remote stream from MCU ->'], stream);
+    //   return;
+    // } else if (!self._sdpSettings.direction.audio.receive && !self._sdpSettings.direction.video.receive) {
+    //   log.warn([targetMid, 'MediaStream', pc.remoteStreamId, 'Ignoring received empty remote stream ->'], stream);
+    //   return;
+    // }
 
     pc.remoteStream = stream;
     pc.remoteStreamId = pc.remoteStreamId || stream.id || stream.label;
@@ -1910,7 +1910,7 @@ Skylink.prototype._createPeerConnection = function(targetMid, isScreenSharing, c
     pc.hasStream = true;
     pc.hasScreen = peerSettings.video && typeof peerSettings.video === 'object' && peerSettings.video.screenshare;
 
-    self._onRemoteStreamAdded(targetMid, stream, !!pc.hasScreen);
+    self._onRemoteStreamAdded(self.streamIdPeerIdMap[stream.id.split('_MCU_')[0]], stream, !!pc.hasScreen);
   };
 
   pc.onremovestream = function(evt) {

--- a/source/peer-connection.js
+++ b/source/peer-connection.js
@@ -1641,32 +1641,37 @@ Skylink.prototype._restartPeerConnection = function (peerId, doIceRestart, bwOpt
  * @since 0.5.5
  */
 Skylink.prototype._removePeer = function(peerId) {
-  if (!this._peerConnections[peerId] && !this._peerInformations[peerId]) {
+  if (!this._peerConnections[peerId] && !this._peerInformations[peerId] && !this._hasMCU) {
     log.debug([peerId, 'RTCPeerConnection', null, 'Dropping the hangup from Peer as not connected to Peer at all.']);
     return;
   }
 
-  var peerInfo = clone(this.getPeerInfo(peerId)) || {
-    userData: '',
-    settings: { audio: false, video: false, data: false },
-    mediaStatus: { audioMuted: true, videoMuted: true },
-    agent: {
-      name: 'unknown',
-      version: 0,
-      os: '',
-      pluginVersion: null
-    },
-    config: {
-      enableDataChannel: true,
-      enableIceRestart: false,
-      enableIceTrickle: true,
-      priorityWeight: 0,
-      publishOnly: false,
-      receiveOnly: true
-    },
-    parentId: null,
-    room: clone(this._selectedRoom)
-  };
+  var peerInfo = null;
+
+  if (!this._hasMCU) {
+    peerInfo = clone(this.getPeerInfo(peerId)) || {
+      userData: '',
+      settings: { audio: false, video: false, data: false },
+      mediaStatus: { audioMuted: true, videoMuted: true },
+      agent: {
+        name: 'unknown',
+        version: 0,
+        os: '',
+        pluginVersion: null
+      },
+      config: {
+        enableDataChannel: true,
+        enableIceRestart: false,
+        enableIceTrickle: true,
+        priorityWeight: 0,
+        publishOnly: false,
+        receiveOnly: true
+      },
+      parentId: null,
+      room: clone(this._selectedRoom)
+    };
+  }
+
 
   if (peerId !== 'MCU') {
     this._trigger('peerLeft', peerId, peerInfo, false);
@@ -1866,32 +1871,6 @@ Skylink.prototype._createPeerConnection = function(targetMid, isScreenSharing, c
 
     var stream = evt.stream || evt;
 
-    // MCU test
-    // function makeFackUserId() {
-    //   var text = "user_";
-    //   var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-    //   for (var i = 0; i < 20; i++)
-    //     text += possible.charAt(Math.floor(Math.random() * possible.length));
-    //   return text;
-    // }
-    // self.peerStreamTable[stream.id] = makeFackUserId();
-    // var video = document.createElement('video');
-    // video.autoplay = true;
-    // video.id = stream.id;
-    // video.peerId = self.streamIdPeerIdMap[stream.id];
-    // window.document.body.append(video);
-    // self.videoRenderers[stream.id] = attachMediaStream(video, stream);
-    // End of MCU test
-
-
-    // if (targetMid === 'MCU') {
-    //   log.warn([targetMid, 'MediaStream', pc.remoteStreamId, 'Ignoring received remote stream from MCU ->'], stream);
-    //   return;
-    // } else if (!self._sdpSettings.direction.audio.receive && !self._sdpSettings.direction.video.receive) {
-    //   log.warn([targetMid, 'MediaStream', pc.remoteStreamId, 'Ignoring received empty remote stream ->'], stream);
-    //   return;
-    // }
-
     pc.remoteStream = stream;
     pc.remoteStreamId = pc.remoteStreamId || stream.id || stream.label;
 
@@ -1910,13 +1889,11 @@ Skylink.prototype._createPeerConnection = function(targetMid, isScreenSharing, c
     pc.hasStream = true;
     pc.hasScreen = peerSettings.video && typeof peerSettings.video === 'object' && peerSettings.video.screenshare;
 
-    self._onRemoteStreamAdded(self.streamIdPeerIdMap[stream.id.split('_MCU_')[0]], stream, !!pc.hasScreen);
+    self._onRemoteStreamAdded(self._hasMCU ? self.streamIdPeerIdMap[stream.id.split('_MCU_')[0]] : targetMid, stream, !!pc.hasScreen);
   };
 
   pc.onremovestream = function(evt) {
     var stream = evt.stream || evt;
-    var renderer = self.videoRenderers[stream.id];
-    document.body.removeChild(renderer);
   };
 
   pc.onicecandidate = function(event) {

--- a/source/peer-connection.js
+++ b/source/peer-connection.js
@@ -1889,7 +1889,7 @@ Skylink.prototype._createPeerConnection = function(targetMid, isScreenSharing, c
     pc.hasStream = true;
     pc.hasScreen = peerSettings.video && typeof peerSettings.video === 'object' && peerSettings.video.screenshare;
 
-    self._onRemoteStreamAdded(self._hasMCU ? self.streamIdPeerIdMap[stream.id.split('_MCU_')[0]] : targetMid, stream, !!pc.hasScreen);
+    self._onRemoteStreamAdded(self._hasMCU ? self.streamIdPeerIdMap[stream.id] : targetMid, stream, !!pc.hasScreen);
   };
 
   pc.onremovestream = function(evt) {

--- a/source/peer-data.js
+++ b/source/peer-data.js
@@ -589,10 +589,10 @@ Skylink.prototype._getPeerCustomSettings = function (peerId) {
 
 
   if (self._peerConnections[usePeerId] && self._peerConnections[usePeerId].signalingState !== self.PEER_CONNECTION_STATE.CLOSED) {
-    var stream = self._peerConnections[peerId].localStream;
-    var streamId = self._peerConnections[peerId].localStreamId || (stream && (stream.id || stream.label));
+    var stream = self._peerConnections[usePeerId].localStream;
+    var streamId = self._peerConnections[usePeerId].localStreamId || (stream && (stream.id || stream.label));
 
-    customSettings.settings.data = self._initOptions.enableDataChannel && self._peerInformations[peerId].config.enableDataChannel;
+    customSettings.settings.data = self._initOptions.enableDataChannel && self._peerInformations[usePeerId].config.enableDataChannel;
 
     if (stream) {
       if (self._streams.screenshare && self._streams.screenshare.stream &&
@@ -608,9 +608,9 @@ Skylink.prototype._getPeerCustomSettings = function (peerId) {
         customSettings.mediaStatus = clone(self._streamsMutedSettings);
       }
 
-      if (typeof self._peerConnections[peerId].getSenders === 'function' &&
+      if (typeof self._peerConnections[usePeerId].getSenders === 'function' &&
         !(self._initOptions.useEdgeWebRTC && window.msRTCPeerConnection)) {
-        var senders = self._peerConnections[peerId].getSenders();
+        var senders = self._peerConnections[usePeerId].getSenders();
         var hasSendAudio = false;
         var hasSendVideo = false;
 

--- a/source/room-init.js
+++ b/source/room-init.js
@@ -182,7 +182,7 @@ Skylink.prototype.generateUUID = function() {
  *   <code>refreshConnection()</code> method</a> is called internally.</small>
  * @param {Boolean} [options.throttleShouldThrowError=false] The flag if throttled methods should throw errors when
  *   method is invoked less than the interval timeout value configured in <code>options.throttleIntervals</code>.
- * @param {Boolean} [options.mcuUseRenegoRestart=false] <blockquote class="info">
+ * @param {Boolean} [options.mcuUseRenegoRestart=true] <blockquote class="info">
  *   Note that this feature is currently is beta and for any enquiries on enabling and its support, please
  *   contact <a href="http://support.temasys.io">our support portal</a>.</blockquote>
  *   The flag if <a href="#method_refreshConnection"><code>
@@ -486,8 +486,8 @@ Skylink.prototype.init = function(_options, _callback) {
   // `init({ throttleShouldThrowError: false })`
   options.throttleShouldThrowError = options.throttleShouldThrowError === true;
 
-  // `init({ mcuUseRenegoRestart: false })`
-  options.mcuUseRenegoRestart = options.mcuUseRenegoRestart === true;
+  // `init({ mcuUseRenegoRestart: true })`
+  options.mcuUseRenegoRestart = options.mcuUseRenegoRestart === false;
 
   // `init({ useEdgeWebRTC: false })`
   options.useEdgeWebRTC = options.useEdgeWebRTC === true;

--- a/source/room-init.js
+++ b/source/room-init.js
@@ -913,6 +913,7 @@ Skylink.prototype._parseInfo = function(info) {
   this._signalingServer = info.ipSigserver;
   this._isPrivileged = info.isPrivileged;
   this._autoIntroduce = info.autoIntroduce;
+  this._hasMCU = info.hasMCU;
 
   this._user = {
     uid: info.username,

--- a/source/skylink-events.js
+++ b/source/skylink-events.js
@@ -797,6 +797,21 @@ var _eventsDocs = {
   recordingState: [],
 
   /**
+   * Event triggered when RTMP session state has changed.
+   * @event rtmpState
+   * @param {Number} state The current RTMP session state.
+   *   [Rel: Skylink.RTMP_STATE]
+   * @param {String} rtmpId The rtmp session ID.
+   * @param {Error|String} error The error object.
+   *   <small>Defined only when <code>state</code> payload is <code>ERROR</code>.</small>
+   * @beta
+   * @for Skylink
+   * @since 0.6.36
+   */
+
+  RTMPState: [],
+
+  /**
    * Event triggered when <a href="#method_getConnectionStatus"><code>getConnectionStatus()</code> method</a>
    * retrieval state changes.
    * @event getConnectionStatusStateChange

--- a/source/socket-message.js
+++ b/source/socket-message.js
@@ -59,7 +59,7 @@ Skylink.prototype.sendMessage = function(message, targetPeerId) {
   for (var i = 0; i < listOfPeers.length; i++) {
     var peerId = listOfPeers[i];
 
-    if (!this._peerInformations[peerId]) {
+    if (!this._hasMCU && !this._peerInformations[peerId]) {
       log.error([peerId, 'Socket', null, 'Dropping of sending message to Peer as ' +
         'Peer session does not exists']);
       listOfPeers.splice(i, 1);

--- a/source/socket-message.js
+++ b/source/socket-message.js
@@ -1053,15 +1053,15 @@ Skylink.prototype._enterHandler = function(message) {
   }
 
   var processPeerFn = function (cert) {
-    if (!self._peerInformations[targetMid]) {
+    if (!self._peerInformations[message.target]) {
       isNewPeer = true;
 
-      self._peerInformations[targetMid] = userInfo;
+      self._peerInformations[message.target] = userInfo;
 
       var hasScreenshare = userInfo.settings.video && typeof userInfo.settings.video === 'object' &&
         !!userInfo.settings.video.screenshare;
 
-      self._addPeer(targetMid, cert || null, {
+      self._addPeer(message.target, cert || null, {
         agent: userInfo.agent.name,
         version: userInfo.agent.version,
         os: userInfo.agent.os
@@ -1071,6 +1071,7 @@ Skylink.prototype._enterHandler = function(message) {
         log.info([targetMid, 'RTCPeerConnection', null, 'MCU feature has been enabled']);
 
         self._hasMCU = true;
+        self._trigger('peerJoined', message.target, self.getPeerInfo(message.target), false);
         self._trigger('serverPeerJoined', targetMid, self.SERVER_PEER_TYPE.MCU);
 
       } else {
@@ -1080,7 +1081,7 @@ Skylink.prototype._enterHandler = function(message) {
       self._trigger('handshakeProgress', self.HANDSHAKE_PROGRESS.ENTER, targetMid);
     }
 
-    self._peerMessagesStamps[targetMid] = self._peerMessagesStamps[targetMid] || {
+    self._peerMessagesStamps[message.target] = self._peerMessagesStamps[message.target] || {
       userData: 0,
       audioMuted: 0,
       videoMuted: 0
@@ -1377,6 +1378,10 @@ Skylink.prototype._welcomeHandler = function(message) {
         log.info([targetMid, 'RTCPeerConnection', null, 'MCU feature has been enabled']);
 
         self._hasMCU = true;
+        for (var peersInRoomIndex = 0; peersInRoomIndex < message.peersInRoom.length; peersInRoomIndex++) {
+          var _PEER_ID = message.peersInRoom[peersInRoomIndex].mid;
+          self._trigger('peerJoined', _PEER_ID, self.getPeerInfo(_PEER_ID), false);
+        }
         self._trigger('serverPeerJoined', targetMid, self.SERVER_PEER_TYPE.MCU);
 
       } else {

--- a/source/socket-message.js
+++ b/source/socket-message.js
@@ -1894,7 +1894,7 @@ Skylink.prototype.startRTMPSession = function (streamId, endpoint, callback) {
     mid: self._user.sid,
     streamId: streamId,
     endpoint: endpoint,
-    rtmpId:rtmpId
+    rtmpId: rtmpId
   });
 
   log.debug(['MCU', 'RTMP', null, 'Starting RTMP Session']);
@@ -1980,7 +1980,7 @@ Skylink.prototype._rtmpEventHandler = function (message) {
 
       self._rtmpSessions[message.rtmpId] = {
         active: true,
-        state: self.RTMPSTATE.START,
+        state: self.RTMP_STATE.START,
         startedDateTime: (new Date()).toISOString(),
         endedDateTime: null,
         peerId: message.peerId,

--- a/source/socket-message.js
+++ b/source/socket-message.js
@@ -1510,8 +1510,14 @@ Skylink.prototype._offerHandler = function(message) {
   self._handleNegotiationStats('offer', targetMid, offer, true);
 
   if (!pc) {
-    log.error([targetMid, null, message.type, 'Peer connection object ' +
+    if(!self._hasMCU) {
+      log.error([targetMid, null, message.type, 'Peer connection object ' +
       'not found. Unable to setRemoteDescription for offer']);
+    }
+    if (targetMid !== 'MCU' && self._hasMCU && self._peerConnections['MCU']) {
+      log.warn([targetMid, null, message.type, 'Peer connection object with MCU ' +
+      'already exists. Dropping the offer.']);
+    }
     self._handleNegotiationStats('dropped_offer', targetMid, offer, true, 'Peer connection does not exists');
     return;
   }

--- a/source/socket-message.js
+++ b/source/socket-message.js
@@ -1698,6 +1698,10 @@ Skylink.prototype._answerHandler = function(message) {
   var targetMid = message.mid;
   var pc = self._peerConnections[targetMid];
 
+  if (targetMid === 'MCU') {
+    self.streamIdPeerIdMap = message.streamIdPeerIdMap || {};
+  }
+
   log.log([targetMid, null, message.type, 'Received answer from peer. Session description:'], clone(message));
 
   var answer = {

--- a/source/socket-message.js
+++ b/source/socket-message.js
@@ -454,7 +454,7 @@ Skylink.prototype._processSigMessage = function(message, session) {
   case this._SIG_MESSAGE_TYPE.RECORDING:
     this._recordingEventHandler(message);
     break;
-  case this._SIG_MESSAGE_TYPE.rtmpEvent:
+  case this._SIG_MESSAGE_TYPE.RTMP:
     this._rtmpEventHandler(message);
     break;
   case this._SIG_MESSAGE_TYPE.END_OF_CANDIDATES:
@@ -1881,7 +1881,7 @@ Skylink.prototype.startRTMPSession = function (streamId, endpoint, callback) {
 
   if (typeof callback === 'function') {
     self.once('RTMPState', function (state, RTMPId) {
-      callback(null, RTMPId);
+      callback(RTMPId);
     }, function (state) {
       return state === self.RTMP_STATE.START;
     });
@@ -1941,7 +1941,7 @@ Skylink.prototype.stopRTMPSession = function (rtmpId, callback) {
 
   if (typeof callback === 'function') {
     self.once('RTMPState', function (state, rtmpId) {
-      callback(null, rtmpId);
+      callback(rtmpId);
     }, function (state) {
       return state === self.RTMP_STATE.STOP;
     });
@@ -1951,6 +1951,7 @@ Skylink.prototype.stopRTMPSession = function (rtmpId, callback) {
     type: self._SIG_MESSAGE_TYPE.STOP_RTMP,
     rid: self._room.id,
     rtmpId: rtmpId,
+    mid: self._user.sid,
     target: 'MCU'
   });
 
@@ -1974,7 +1975,7 @@ Skylink.prototype._rtmpEventHandler = function (message) {
 
   log.debug(['MCU', 'RTMP', null, 'Received RTMP Session message ->'], message);
 
-  if (message.action === 'on') {
+  if (message.action === 'startSuccess') {
     if (!self._rtmpSessions[message.rtmpId]) {
       log.debug(['MCU', 'RTMP', message.rtmpId, 'Started RTMP Session']);
 
@@ -1989,7 +1990,7 @@ Skylink.prototype._rtmpEventHandler = function (message) {
       self._trigger('RTMPState', self.RTMP_STATE.START, message.rtmpId, null, null);
     }
 
-  } else if (message.action === 'off') {
+  } else if (message.action === 'stopSuccess') {
 
     if (!self._rtmpSessions[message.rtmpId]) {
       log.error(['MCU', 'RTMP', message.rtmpId, 'Received request of "off" but the session is empty']);

--- a/source/socket-message.js
+++ b/source/socket-message.js
@@ -1888,7 +1888,7 @@ Skylink.prototype.startRTMPSession = function (streamId, endpoint, callback) {
   }
 
   self._sendChannelMessage({
-    type: self._SIG_MESSAGE_TYPE.startRTMP,
+    type: self._SIG_MESSAGE_TYPE.START_RTMP,
     rid: self._room.id,
     target: 'MCU',
     mid: self._user.sid,

--- a/source/stream-media.js
+++ b/source/stream-media.js
@@ -2111,10 +2111,10 @@ Skylink.prototype._onRemoteStreamAdded = function(targetMid, stream, isScreenSha
   var self = this;
   var streamId = (self._peerConnections[targetMid] && self._peerConnections[targetMid].remoteStreamId) || stream.id || stream.label;
 
-  if (!self._peerInformations[targetMid]) {
-    log.warn([targetMid, 'MediaStream', streamId, 'Received remote stream when peer is not connected. Ignoring stream ->'], stream);
-    return;
-  }
+  // if (!self._peerInformations[targetMid]) {
+  //   log.warn([targetMid, 'MediaStream', streamId, 'Received remote stream when peer is not connected. Ignoring stream ->'], stream);
+  //   return;
+  // }
 
   /*if (!self._peerInformations[targetMid].settings.audio &&
     !self._peerInformations[targetMid].settings.video && !isScreenSharing) {

--- a/source/stream-sdp.js
+++ b/source/stream-sdp.js
@@ -792,9 +792,9 @@ Skylink.prototype._handleSDPConnectionSettings = function (targetMid, sessionDes
   // Apply as a=inactive when supported
   if (self._hasMCU) {
     var peerStreamSettings = clone(self.getPeerInfo(targetMid)).settings || {};
-    settings.direction.audio.receive = targetMid === 'MCU' ? false : !!peerStreamSettings.audio;
+    settings.direction.audio.receive = targetMid === 'MCU' ? true : !!peerStreamSettings.audio;
     settings.direction.audio.send = targetMid === 'MCU' ? true : false;
-    settings.direction.video.receive = targetMid === 'MCU' ? false : !!peerStreamSettings.video;
+    settings.direction.video.receive = targetMid === 'MCU' ? true : !!peerStreamSettings.video;
     settings.direction.video.send = targetMid === 'MCU' ? true : false;
   }
 

--- a/source/template/header.js
+++ b/source/template/header.js
@@ -741,6 +741,17 @@ function Skylink() {
   this._recordings = {};
 
   /**
+   * Stores the list of RTMP Sessions.
+   * @attribute _rtmpSessions
+   * @type JSON
+   * @private
+   * @beta
+   * @for Skylink
+   * @since 0.6.36
+   */
+  this._rtmpSessions = {};
+
+  /**
    * Stores the current active recording session ID.
    * There can only be 1 recording session at a time in a Room
    * @attribute _currentRecordingId


### PR DESCRIPTION
1. Support for RTMP messages and Events
2. Support for New MCU
-- Set default value mcuUseRenegoRestart to true
-- Setting the _hasMCU flag from API response rather than socket message listeners
-- Fixed: Existing issue in getPeerCustomSettings
-- Fixes to PeerLeft and RemovePeer for New MCU
-- SendP2PMessage and SendSIGMessage support for new MCU.

