### PR TITLE
Adding app_key field to handleBandwidthStats function

### DIFF
--- a/source/skylink-stats.js
+++ b/source/skylink-stats.js
@@ -249,6 +249,7 @@ Skylink.prototype._handleNegotiationStats = function(state, peerId, sdpOrMessage
 Skylink.prototype._handleBandwidthStats = function (peerId) {
   var self = this;
   var statsObject = {
+    app_key: self._initOptions.appKey,
     room_id: self._room && self._room.id,
     user_id: self._user && self._user.sid,
     peer_id: peerId,


### PR DESCRIPTION
**Purpose of this PR:**
To add `app_key` to the request body for `Skylink.prototype._handleBandwidthStats` function

See [ESS-1332](https://jira.temasys.com.sg/browse/ESS-1332) for more details. 