### PR TITLE
Report calls to console.error to stats sever endpoint

### DIFF
--- a/source/room-init.js
+++ b/source/room-init.js
@@ -736,6 +736,8 @@ Skylink.prototype.init = function(_options, _callback) {
     return;
   }
 
+  self._setClientInfoForLogging();
+
   // Format: https://api.temasys.io/api/<appKey>/<room>[/<creds.start>][/<creds.duration>][?cred=<creds.hash>]&rand=<rand>
   self._path = self._initOptions.roomServer + '/api/' + self._initOptions.appKey + '/' + self._selectedRoom +
     (self._initOptions.credentials ? '/' + self._initOptions.credentials.startDateTime + '/' +

--- a/source/skylink-debug.js
+++ b/source/skylink-debug.js
@@ -96,6 +96,20 @@ var _printTimestamp = false;
 var _storedLogs = [];
 
 /**
+ * Stores the user's info for reporting error to API
+ * @attribute _userInfo
+ * @type JSON
+ * @private
+ * @scoped true
+ * @for Skylink
+ * @since 0.6.35
+ */
+var _reportErrorConfig = {
+  app_key: null,
+  statsServer: null
+};
+
+/**
  * Function that gets the stored logs.
  * @method _getStoredLogsFn
  * @private
@@ -225,6 +239,35 @@ var SkylinkLogs = {
 };
 
 /**
+ * Function that will send the log to an API endpoint for persistence
+ * @method _reportToAPI
+ * @private
+ * @required
+ * @scoped true
+ * @for Skylink
+ * @since 0.6.35
+ */
+var _reportToAPI = function(message, object) {
+  var endpoint = '/rest/stats/sessionerror';
+  var statsServer = _reportErrorConfig.statsServer;
+  var requestBody = {
+    data: {
+      message: message,
+      object: object,
+    }
+  };
+  requestBody.app_key = _reportErrorConfig.app_key;
+  requestBody.timestamp = (new Date()).toISOString();
+  try {
+    var xhr = new XMLHttpRequest();
+    xhr.onerror = function () { };
+    xhr.open('POST', statsServer + endpoint, true);
+    xhr.setRequestHeader('Content-Type', 'application/json;charset=UTF-8');
+    xhr.send(JSON.stringify(requestBody));
+  } catch (error) {}
+};
+
+/**
  * Function that handles the logs received and prints in the Web Console interface according to the log level set.
  * @method _logFn
  * @private
@@ -328,6 +371,7 @@ var log = {
   },
 
   error: function (message, object) {
+    _reportToAPI(message, object);
     _logFn(0, message, object);
   }
 };
@@ -416,4 +460,19 @@ Skylink.prototype.setDebugMode = function(isDebugMode) {
     _enableDebugStack = false;
     _printTimestamp = false;
   }
+};
+
+
+/**
+ * Function that populates the userInfo object with appKey and client ID used for logging an error and reporting to API server
+ * @method _setClientInfoForLogging
+ * @param {String} appKey
+ * @param {String} clientId
+ * @for Skylink
+ * @since 0.5.5
+ */
+Skylink.prototype._setClientInfoForLogging = function() {
+  var initOptions = this._initOptions;
+  _reportErrorConfig.app_key = initOptions.appKey;
+  _reportErrorConfig.statsServer = initOptions.statsServer;
 };


### PR DESCRIPTION
**Purpose of this PR:**
To enable posting of errors `console.error` messages to stats server i.e. all calls to `log.error(...)` will be sent to an endpoint for storage.

See [ESS-1331](https://jira.temasys.com.sg/browse/ESS-1331) for more details. 