### PR TITLE
Null Check for gatheredCandidates if peer disconnection before 6000ms

### DIFF
--- a/source/ice-candidate.js
+++ b/source/ice-candidate.js
@@ -119,15 +119,17 @@ Skylink.prototype._onIceCandidate = function(targetMid, candidate) {
       });
     } else if (self._gatheredCandidates[targetMid]) {
       var sendEndOfCandidates = function() {
-        self._sendChannelMessage({
-          type: self._SIG_MESSAGE_TYPE.END_OF_CANDIDATES,
-          noOfExpectedCandidates: self._gatheredCandidates[targetMid].sending.srflx.length +
-            self._gatheredCandidates[targetMid].sending.host.length +
-            self._gatheredCandidates[targetMid].sending.relay.length,
-          mid: self._user.sid,
-          target: targetMid,
-          rid: self._room.id
-        });
+        if (self._gatheredCandidates[targetMid] && self._gatheredCandidates[targetMid].sending) {
+          self._sendChannelMessage({
+            type: self._SIG_MESSAGE_TYPE.END_OF_CANDIDATES,
+            noOfExpectedCandidates: self._gatheredCandidates[targetMid].sending.srflx.length +
+              self._gatheredCandidates[targetMid].sending.host.length +
+              self._gatheredCandidates[targetMid].sending.relay.length,
+            mid: self._user.sid,
+            target: targetMid,
+            rid: self._room.id
+          });
+        }
       };
       setTimeout(sendEndOfCandidates, 6000);
     }


### PR DESCRIPTION
**Purpose of this PR:**
The purpose is to fix the issue where `sendEndOfCandidates` function throws a runtime JS error for null `gatheredCandidates` if a peer joins and disconnects within an interval of `6000ms`.

See [ESS-1291](https://jira.temasys.com.sg/browse/ESS-1291) for more details.