### PR TITLE
Fixing loop to enumerate on dataChannels[peerId] instead of all dataChannels

### DIFF
--- a/source/data-channel.js
+++ b/source/data-channel.js
@@ -395,7 +395,7 @@ Skylink.prototype._closeDataChannel = function(peerId, channelProp, isCloseMainC
     closeFn(channelProp);
   }
   else if (!channelProp || channelProp === 'main') {
-    for (var channelNameProp in self._dataChannels) {
+    for (var channelNameProp in self._dataChannels[peerId]) {
       if (self._dataChannels[peerId].hasOwnProperty(channelNameProp)) {
         if (self._dataChannels[peerId][channelNameProp]) {
           closeFn(channelNameProp);


### PR DESCRIPTION
**Purpose of this PR:**
The purpose is to fix the for-in loop inside `_closeDataChannels` to enumerate on `self._dataChannels[peerId]` instead of `self._dataChannels`

See [ESS-1333](https://jira.temasys.com.sg/browse/ESS-1086) for more details.