### PR TITLE
ESS-1336 - Setting remoteDescription (answer) fails on Firefox 63.0.3 | MCU key only

### DIFF
--- a/source/peer-handshake.js
+++ b/source/peer-handshake.js
@@ -203,6 +203,7 @@ Skylink.prototype._setLocalAndSendMessage = function(targetMid, _sessionDescript
   sessionDescription.sdp = self._removeSDPCodecs(targetMid, sessionDescription);
   sessionDescription.sdp = self._handleSDPConnectionSettings(targetMid, sessionDescription, 'local');
   sessionDescription.sdp = self._removeSDPREMBPackets(targetMid, sessionDescription);
+  sessionDescription.sdp = self._setSCTPport(targetMid, sessionDescription);
 
   if (self._peerConnectionConfig.disableBundle) {
     sessionDescription.sdp = sessionDescription.sdp.replace(/a=group:BUNDLE.*\r\n/gi, '');

--- a/source/socket-message.js
+++ b/source/socket-message.js
@@ -1741,6 +1741,7 @@ Skylink.prototype._answerHandler = function(message) {
   answer.sdp = self._removeSDPREMBPackets(targetMid, answer);
   answer.sdp = self._handleSDPConnectionSettings(targetMid, answer, 'remote');
   answer.sdp = self._removeSDPUnknownAptRtx(targetMid, answer);
+  answer.sdp = self._setSCTPport(targetMid, answer);
 
   log.log([targetMid, 'RTCSessionDescription', message.type, 'Updated remote answer ->'], answer.sdp);
 

--- a/source/stream-sdp.js
+++ b/source/stream-sdp.js
@@ -1415,11 +1415,14 @@ Skylink.prototype._setSCTPport = function (targetMid, sessionDescription) {
         // Saving m=application line when creating offer into instance variable
         if (sdpType === 'offer') {
           self._mline = sdpLines[mLineIndex];
+          break;
         }
 
         // Replacing m=application line from instance variable
         if (sdpType === 'answer') {
           sdpLines[mLineIndex] = self._mline;
+          sdpLines.splice(mLineIndex + 1, 0, 'a=sctp-port:5000');
+          break;
         }
       }
     }

--- a/source/stream-sdp.js
+++ b/source/stream-sdp.js
@@ -1388,3 +1388,44 @@ Skylink.prototype._getSDPCommonSupports = function (targetMid, sessionDescriptio
 
   return offer;
 };
+
+/**
+ * Function adds SCTP port number for Firefox 63.0.3 and above if its missing in the answer from MCU
+ * @method _setSCTPport
+ * @private
+ * @for Skylink
+ * @since 0.6.35
+ */
+Skylink.prototype._setSCTPport = function (targetMid, sessionDescription) {
+  var self = this;
+  if (AdapterJS.webrtcDetectedBrowser === 'firefox' && AdapterJS.webrtcDetectedVersion >= 63 && self._hasMCU === true) {
+    var sdpLines = sessionDescription.sdp.split('\r\n');
+    var mLineType = 'application';
+    var mLineIndex = -1;
+    var sdpType = sessionDescription.type;
+
+    for (var i = 0; i < sdpLines.length; i++) {
+      if (sdpLines[i].indexOf('m=' + mLineType) === 0) {
+        mLineIndex = i;
+      } else if (mLineIndex > 0) {
+        if (sdpLines[i].indexOf('m=') === 0) {
+          break;
+        }
+
+        // Saving m=application line when creating offer into instance variable
+        if (sdpType === 'offer') {
+          self._mline = sdpLines[mLineIndex];
+        }
+
+        // Replacing m=application line from instance variable
+        if (sdpType === 'answer') {
+          sdpLines[mLineIndex] = self._mline;
+        }
+      }
+    }
+
+    return sdpLines.join('\r\n');
+  }
+
+  return sessionDescription.sdp;
+};


### PR DESCRIPTION
**Purpose of this PR:**
The purpose is to fix the issue where on Firefox 63.0.3 (latest version as of this PR) the setting of `remoteDescription` sdp answer in `_answerHandler` fails with an error: 

Please note that this exception occurs when MCU is enabled.

`DOMException: Failed to parse SDP. SDP Parse error on line 53: No sctp port specified in m= media line, parse failed`

**What was changed**
The `m=application` is saved in a variable when the browser (FF) generates the `offer`. When MCU sends the `answer`, the `m=application` line is replaced with the one from the `offer` sdp. This happens only for Firefox 63 and above when MCU is on.

See [ESS-1336](https://jira.temasys.com.sg/browse/ESS-1336) for more details.