### PR TITLE
ESS-1347: Change log type of timestamp check to Warning for joinRoom

### DIFF
--- a/source/room-connection.js
+++ b/source/room-connection.js
@@ -341,10 +341,14 @@ Skylink.prototype.joinRoom = function(room, options, callback) {
     }
   };
 
+  var resolveAsWarningFn = function(error, tryRoom) {
+    log.warn(error + ' ' + 'room: ' + tryRoom);
+  };
+
   var joinRoomFn = function () {
     // If room has been stopped but does not matches timestamp skip.
     if (self._joinRoomManager.timestamp !== timestamp) {
-      resolveAsErrorFn('joinRoom() process did not complete', selectedRoom);
+      resolveAsWarningFn('joinRoom() process did not complete', selectedRoom);
       return;
     }
 
@@ -354,7 +358,7 @@ Skylink.prototype.joinRoom = function(room, options, callback) {
         return;
       // If details has been initialised but does not matches timestamp skip.
       } else if (self._joinRoomManager.timestamp !== timestamp) {
-        resolveAsErrorFn('joinRoom() process did not complete', selectedRoom);
+        resolveAsWarningFn('joinRoom() process did not complete', selectedRoom);
         return;
       }
 
@@ -364,7 +368,7 @@ Skylink.prototype.joinRoom = function(room, options, callback) {
           return;
         // If socket and stream has been retrieved but socket connection does not matches timestamp skip.
         } else if (self._joinRoomManager.timestamp !== timestamp) {
-          resolveAsErrorFn('joinRoom() process did not complete', selectedRoom);
+          resolveAsWarningFn('joinRoom() process did not complete', selectedRoom);
           return;
         }
 


### PR DESCRIPTION
**Purpose of this PR:**
To change the log type for the situation when multiple join rooms happen to `logger.warning` as `joinRoom` succeeds eventually with the most recent call to `joinRoom` 

See [ESS-1347](https://jira.temasys.com.sg/browse/ESS-1347) for more details. 