### PR TITLE
ESS: 1404: Adding sdpSemantics as plan-b for Chrome

### DIFF
--- a/source/peer-connection.js
+++ b/source/peer-connection.js
@@ -1790,6 +1790,11 @@ Skylink.prototype._createPeerConnection = function(targetMid, isScreenSharing, c
 
   // currently the AdapterJS 0.12.1-2 causes an issue to prevent firefox from
   // using .urls feature
+
+  if (AdapterJS.webrtcDetectedBrowser === 'chrome') {
+    constraints.sdpSemantics = 'plan-b';
+  }
+
   try {
     log.debug([targetMid, 'RTCPeerConnection', null, 'Creating peer connection ->'], {
       constraints: constraints,


### PR DESCRIPTION
**Purpose of this PR:**
As chrome is moving towards switching default to `unfied-plan,` we need to, as of now, force chrome to stay on `plan-b`. Note that this is a chrome only flag and other browsers will ignore it. 

See [ESS-1404](https://jira.temasys.com.sg/browse/ESS-1404) for more details. 