### PR TITLE
ESS-1411: Remove @beta from startRecording and stopRecording

### DIFF
--- a/source/socket-message.js
+++ b/source/socket-message.js
@@ -142,7 +142,6 @@ Skylink.prototype.sendMessage = function(message, targetPeerId) {
  *   <li>If recording session has been started successfully: <ol>
  *   <li><a href="#event_recordingState"><code>recordingState</code> event</a> triggers
  *   parameter payload <code>state</code> as <code>START</code>.</li></ol></li></ol></li></ol>
- * @beta
  * @for Skylink
  * @since 0.6.16
  */
@@ -253,7 +252,6 @@ Skylink.prototype.startRecording = function (callback) {
  *   <li><a href="#event_recordingState"><code>recordingState</code> event</a>
  *   triggers parameter payload <code>state</code> as <code>ERROR</code>.</li><li><b>ABORT</b> and return error.</li>
  *   </ol></li></ol></li></ol>
- * @beta
  * @for Skylink
  * @since 0.6.16
  */


### PR DESCRIPTION
**Purpose of this PR:**
To remove `@beta` tags from `startRecording` and `stopRecording` methods.

See [ESS-1411](https://jira.temasys.com.sg/browse/ESS-1411) for more details. 