### PR TITLE
ESS-1414: Renaming error parameter correctly in callback

### DIFF
--- a/source/peer-connection.js
+++ b/source/peer-connection.js
@@ -519,8 +519,8 @@ Skylink.prototype.getConnectionStatus = function (targetPeerId, callback) {
 
   var statsFn = function (peerId) {
     var retrieveFn = function (firstRetrieval, nextCb) {
-      return function (err, result) {
-        if (err) {
+      return function (error, result) {
+        if (error) {
           log.error([peerId, 'RTCStatsReport', null, 'Retrieval failure ->'], error);
           listOfPeerErrors[peerId] = error;
           self._trigger('getConnectionStatusStateChange', self.GET_CONNECTION_STATUS_STATE.RETRIEVE_ERROR,


### PR DESCRIPTION
**Purpose of this PR:**
The error parameter for anonymous function returned by `retrieveFn` was incorrectly named to `err` and referred to as `error` in the scope below it. This PR is to rename it correctly to avoid undef errors.

See [ESS-1414](https://jira.temasys.com.sg/browse/ESS-1414) for more details. 