### PR TITLE
ESS-1415: New MCU Changes for Unified Plan

### DIFF
--- a/source/peer-handshake.js
+++ b/source/peer-handshake.js
@@ -34,6 +34,7 @@ Skylink.prototype._doOffer = function(targetMid, iceRestart) {
 
   // Add stream only at offer/answer end
   if (!self._hasMCU || targetMid === 'MCU') {
+    self._compareTrackCounts(targetMid);
     self._addLocalMediaStreams(targetMid);
   }
 

--- a/source/socket-message.js
+++ b/source/socket-message.js
@@ -1127,6 +1127,7 @@ Skylink.prototype._enterHandler = function(message) {
 Skylink.prototype._restartHandler = function(message){
   var self = this;
   var targetMid = message.mid;
+  var trackCount = message.trackCount;
   var userInfo = message.userInfo || {};
   userInfo.settings = userInfo.settings || {};
   userInfo.mediaStatus = userInfo.mediaStatus || {};
@@ -1165,6 +1166,10 @@ Skylink.prototype._restartHandler = function(message){
     DTProtocolVersion: message.DTProtocolVersion && typeof message.DTProtocolVersion === 'string' ?
       message.DTProtocolVersion : (self._hasMCU || targetMid === 'MCU' ? '0.1.2' : '0.1.0')
   };
+
+  if (trackCount) {
+    self._currentRequestedTracks = trackCount;
+  }
 
   log.log([targetMid, 'RTCPeerConnection', null, 'Peer "restart" received ->'], message);
   self._handleNegotiationStats('restart', targetMid, message, true);
@@ -1271,6 +1276,7 @@ Skylink.prototype._welcomeHandler = function(message) {
   var self = this;
   var targetMid = message.mid;
   var isNewPeer = false;
+  var trackCount = message.trackCount;
   var userInfo = message.userInfo || {};
   userInfo.settings = userInfo.settings || {};
   userInfo.mediaStatus = userInfo.mediaStatus || {};
@@ -1309,6 +1315,10 @@ Skylink.prototype._welcomeHandler = function(message) {
     DTProtocolVersion: message.DTProtocolVersion && typeof message.DTProtocolVersion === 'string' ?
       message.DTProtocolVersion : (self._hasMCU || targetMid === 'MCU' ? '0.1.2' : '0.1.0')
   };
+
+  if (trackCount) {
+    self._currentRequestedTracks = trackCount;
+  }
 
   log.log([targetMid, 'RTCPeerConnection', null, 'Peer "welcome" received ->'], message);
   self._handleNegotiationStats('welcome', targetMid, message, true);
@@ -1680,7 +1690,7 @@ Skylink.prototype._answerHandler = function(message) {
   var pc = self._peerConnections[targetMid];
 
   if (targetMid === 'MCU') {
-    self.streamIdPeerIdMap = message.streamIdPeerIdMap || {};
+    self._transceiverIdPeerIdMap = message.transceiverIdPeerIdMap || {};
   }
 
   log.log([targetMid, null, message.type, 'Received answer from peer. Session description:'], clone(message));

--- a/source/template/header.js
+++ b/source/template/header.js
@@ -878,4 +878,24 @@ function Skylink() {
    */
   this._statIdRandom = Date.now() + Math.floor(Math.random() * 100000000);
 
+  /**
+   * A mapping of transceiverIds and peer IDs (only when new MCU is in effect)
+   * @attribute _transceiverIdPeerIdMap
+   * @type Object
+   * @private
+   * @for Skylink
+   * @since 0.6.31
+   */
+  this._transceiverIdPeerIdMap = {};
+
+  /**
+   * (Extra) Tracks requested by the Peer/MCU in welcome/restart message. Used to create transceivers before createOffer.
+   * @attribute _transceiverIdPeerIdMap
+   * @type Object
+   * @private
+   * @for Skylink
+   * @since 0.6.31
+   */
+  this._currentRequestedTracks = { audio: 0, video: 0 };
+
 }


### PR DESCRIPTION
**Purpose of this PR:**
As chrome is moving towards switching default to `unfied-plan`, the MCU team has made changes to support the new `SDP` and hence some fine tuning is needed in 1.x.x SDK to enable the transition.

- `onaddstream` is now changed to `ontrack`
- `streamIdPeerIdMap` is changed to `transceiverIdPeerIdMap` [Look up `transceiverMid` in `RTCTrackEvent` parameter of `ontrack`]
- A new method `compareTrackCounts` is added to decide if new `Transceivers` are needed in local SDP before sending an `offer`


See [ESS-1415](https://jira.temasys.com.sg/browse/ESS-1415) for more details. 