### PR TITLE
MCU-438: Changes required to incorporate New MCU w/ Unified Plan SDP

### DIFF
--- a/source/peer-handshake.js
+++ b/source/peer-handshake.js
@@ -198,13 +198,13 @@ Skylink.prototype._setLocalAndSendMessage = function(targetMid, _sessionDescript
     sdp: _sessionDescription.sdp
   };
 
-  sessionDescription.sdp = self._removeSDPFirefoxH264Pref(targetMid, sessionDescription);
-  sessionDescription.sdp = self._setSDPCodecParams(targetMid, sessionDescription);
-  sessionDescription.sdp = self._removeSDPUnknownAptRtx(targetMid, sessionDescription);
-  sessionDescription.sdp = self._removeSDPCodecs(targetMid, sessionDescription);
-  sessionDescription.sdp = self._handleSDPConnectionSettings(targetMid, sessionDescription, 'local');
-  sessionDescription.sdp = self._removeSDPREMBPackets(targetMid, sessionDescription);
-  sessionDescription.sdp = self._setSCTPport(targetMid, sessionDescription);
+  // sessionDescription.sdp = self._removeSDPFirefoxH264Pref(targetMid, sessionDescription);
+  // sessionDescription.sdp = self._setSDPCodecParams(targetMid, sessionDescription);
+  // sessionDescription.sdp = self._removeSDPUnknownAptRtx(targetMid, sessionDescription);
+  // sessionDescription.sdp = self._removeSDPCodecs(targetMid, sessionDescription);
+  // sessionDescription.sdp = self._handleSDPConnectionSettings(targetMid, sessionDescription, 'local');
+  // sessionDescription.sdp = self._removeSDPREMBPackets(targetMid, sessionDescription);
+  // sessionDescription.sdp = self._setSCTPport(targetMid, sessionDescription);
 
   if (self._peerConnectionConfig.disableBundle) {
     sessionDescription.sdp = sessionDescription.sdp.replace(/a=group:BUNDLE.*\r\n/gi, '');
@@ -236,7 +236,7 @@ Skylink.prototype._setLocalAndSendMessage = function(targetMid, _sessionDescript
 
     self._sendChannelMessage({
       type: sessionDescription.type,
-      sdp: self._renderSDPOutput(targetMid, sessionDescription),
+      sdp: sessionDescription.sdp,
       mid: self._user.sid,
       target: targetMid,
       rid: self._room.id,

--- a/source/socket-message.js
+++ b/source/socket-message.js
@@ -1083,9 +1083,8 @@ Skylink.prototype._enterHandler = function(message) {
       }
 
       self._sendChannelMessage(welcomeMsg);
+      self._handleNegotiationStats('welcome', targetMid, welcomeMsg, false);
     }
-
-    self._handleNegotiationStats('welcome', targetMid, welcomeMsg, false);
 
     if (isNewPeer) {
       self._trigger('handshakeProgress', self.HANDSHAKE_PROGRESS.WELCOME, targetMid);

--- a/source/socket-message.js
+++ b/source/socket-message.js
@@ -1052,7 +1052,7 @@ Skylink.prototype._enterHandler = function(message) {
       videoMuted: 0
     };
 
-    if (self._hasMCU === true) {
+    if (self._hasMCU !== true) {
       var welcomeMsg = {
         type: self._SIG_MESSAGE_TYPE.WELCOME,
         mid: self._user.sid,

--- a/source/socket-message.js
+++ b/source/socket-message.js
@@ -1052,36 +1052,39 @@ Skylink.prototype._enterHandler = function(message) {
       videoMuted: 0
     };
 
-    var welcomeMsg = {
-      type: self._SIG_MESSAGE_TYPE.WELCOME,
-      mid: self._user.sid,
-      rid: self._room.id,
-      enableIceTrickle: self._initOptions.enableIceTrickle,
-      enableDataChannel: self._initOptions.enableDataChannel,
-      enableIceRestart: self._enableIceRestart,
-      agent: AdapterJS.webrtcDetectedBrowser,
-      version: (AdapterJS.webrtcDetectedVersion || 0).toString(),
-      receiveOnly: self.getPeerInfo().config.receiveOnly,
-      os: window.navigator.platform,
-      userInfo: self._getUserInfo(targetMid),
-      target: targetMid,
-      weight: self._peerPriorityWeight,
-      temasysPluginVersion: AdapterJS.WebRTCPlugin.plugin ? AdapterJS.WebRTCPlugin.plugin.VERSION : null,
-      SMProtocolVersion: self.SM_PROTOCOL_VERSION,
-      DTProtocolVersion: self.DT_PROTOCOL_VERSION
-    };
-
-    if (self._publishOnly) {
-      welcomeMsg.publishOnly = {
-        type: self._streams.screenshare && self._streams.screenshare.stream ? 'screenshare' : 'video'
+    if (self._hasMCU === true) {
+      var welcomeMsg = {
+        type: self._SIG_MESSAGE_TYPE.WELCOME,
+        mid: self._user.sid,
+        rid: self._room.id,
+        enableIceTrickle: self._initOptions.enableIceTrickle,
+        enableDataChannel: self._initOptions.enableDataChannel,
+        enableIceRestart: self._enableIceRestart,
+        agent: AdapterJS.webrtcDetectedBrowser,
+        version: (AdapterJS.webrtcDetectedVersion || 0).toString(),
+        receiveOnly: self.getPeerInfo().config.receiveOnly,
+        os: window.navigator.platform,
+        userInfo: self._getUserInfo(targetMid),
+        target: targetMid,
+        weight: self._peerPriorityWeight,
+        temasysPluginVersion: AdapterJS.WebRTCPlugin.plugin ? AdapterJS.WebRTCPlugin.plugin.VERSION : null,
+        SMProtocolVersion: self.SM_PROTOCOL_VERSION,
+        DTProtocolVersion: self.DT_PROTOCOL_VERSION
       };
+
+      if (self._publishOnly) {
+        welcomeMsg.publishOnly = {
+          type: self._streams.screenshare && self._streams.screenshare.stream ? 'screenshare' : 'video'
+        };
+      }
+
+      if (self._parentId) {
+        welcomeMsg.parentId = self._parentId;
+      }
+
+      self._sendChannelMessage(welcomeMsg);
     }
 
-    if (self._parentId) {
-      welcomeMsg.parentId = self._parentId;
-    }
-
-    self._sendChannelMessage(welcomeMsg);
     self._handleNegotiationStats('welcome', targetMid, welcomeMsg, false);
 
     if (isNewPeer) {
@@ -1510,14 +1513,14 @@ Skylink.prototype._offerHandler = function(message) {
 
   log.log([targetMid, 'RTCSessionDescription', message.type, 'Session description object created'], offer);
 
-  offer.sdp = self._removeSDPFilteredCandidates(targetMid, offer);
-  offer.sdp = self._setSDPCodec(targetMid, offer);
-  offer.sdp = self._setSDPBitrate(targetMid, offer);
-  offer.sdp = self._setSDPCodecParams(targetMid, offer);
-  offer.sdp = self._removeSDPCodecs(targetMid, offer);
-  offer.sdp = self._removeSDPREMBPackets(targetMid, offer);
-  offer.sdp = self._handleSDPConnectionSettings(targetMid, offer, 'remote');
-  offer.sdp = self._removeSDPUnknownAptRtx(targetMid, offer);
+  // offer.sdp = self._removeSDPFilteredCandidates(targetMid, offer);
+  // offer.sdp = self._setSDPCodec(targetMid, offer);
+  // offer.sdp = self._setSDPBitrate(targetMid, offer);
+  // offer.sdp = self._setSDPCodecParams(targetMid, offer);
+  // offer.sdp = self._removeSDPCodecs(targetMid, offer);
+  // offer.sdp = self._removeSDPREMBPackets(targetMid, offer);
+  // offer.sdp = self._handleSDPConnectionSettings(targetMid, offer, 'remote');
+  // offer.sdp = self._removeSDPUnknownAptRtx(targetMid, offer);
 
   log.log([targetMid, 'RTCSessionDescription', message.type, 'Updated remote offer ->'], offer.sdp);
 
@@ -1547,7 +1550,7 @@ Skylink.prototype._offerHandler = function(message) {
     self._trigger('peerUpdated', targetMid, self.getPeerInfo(targetMid), false);
   }
 
-  self._parseSDPMediaStreamIDs(targetMid, offer);
+  // self._parseSDPMediaStreamIDs(targetMid, offer);
 
   var onSuccessCbFn = function() {
     log.debug([targetMid, 'RTCSessionDescription', message.type, 'Remote description set']);
@@ -1731,15 +1734,15 @@ Skylink.prototype._answerHandler = function(message) {
     return;
   }*/
 
-  answer.sdp = self._removeSDPFilteredCandidates(targetMid, answer);
-  answer.sdp = self._setSDPCodec(targetMid, answer);
-  answer.sdp = self._setSDPBitrate(targetMid, answer);
-  answer.sdp = self._setSDPCodecParams(targetMid, answer);
-  answer.sdp = self._removeSDPCodecs(targetMid, answer);
-  answer.sdp = self._removeSDPREMBPackets(targetMid, answer);
-  answer.sdp = self._handleSDPConnectionSettings(targetMid, answer, 'remote');
-  answer.sdp = self._removeSDPUnknownAptRtx(targetMid, answer);
-  answer.sdp = self._setSCTPport(targetMid, answer);
+  // answer.sdp = self._removeSDPFilteredCandidates(targetMid, answer);
+  // answer.sdp = self._setSDPCodec(targetMid, answer);
+  // answer.sdp = self._setSDPBitrate(targetMid, answer);
+  // answer.sdp = self._setSDPCodecParams(targetMid, answer);
+  // answer.sdp = self._removeSDPCodecs(targetMid, answer);
+  // answer.sdp = self._removeSDPREMBPackets(targetMid, answer);
+  // answer.sdp = self._handleSDPConnectionSettings(targetMid, answer, 'remote');
+  // answer.sdp = self._removeSDPUnknownAptRtx(targetMid, answer);
+  // answer.sdp = self._setSCTPport(targetMid, answer);
 
   log.log([targetMid, 'RTCSessionDescription', message.type, 'Updated remote answer ->'], answer.sdp);
 
@@ -1769,7 +1772,7 @@ Skylink.prototype._answerHandler = function(message) {
     self._trigger('peerUpdated', targetMid, self.getPeerInfo(targetMid), false);
   }
 
-  self._parseSDPMediaStreamIDs(targetMid, answer);
+  // self._parseSDPMediaStreamIDs(targetMid, answer);
 
 
   var onSuccessCbFn = function() {


### PR DESCRIPTION
**Purpose of this PR:**
As chrome is moving towards switching default to `unfied-plan`, the MCU team has made changes to support the new `SDP` and hence some fine tuning is needed in 1.x.x SDK to enable the transition.

- Removed SDP munging methods as we should not alter the SDP in unified plan. New MCU now works with default unified SDP (w/o munging)
- If new MCU is in the room, SDK should not reply to an Enter message - changed in `fn:enterHandler`


See [MCU-438](https://jira.temasys.com.sg/browse/MCU-438) for more details. 