### PR TITLE
ESS-1454: Implement acknowledgement of answer message

### DIFF
--- a/source/constants.js
+++ b/source/constants.js
@@ -1425,6 +1425,7 @@ Skylink.prototype._SIG_MESSAGE_TYPE = {
   RESTART: 'restart',
   OFFER: 'offer',
   ANSWER: 'answer',
+  ANSWER_ACK: 'answerAck',
   CANDIDATE: 'candidate',
   BYE: 'bye',
   REDIRECT: 'redirect',

--- a/source/socket-message.js
+++ b/source/socket-message.js
@@ -1777,6 +1777,7 @@ Skylink.prototype._answerHandler = function(message) {
     pc.setAnswer = 'remote';
     pc.processingRemoteSDP = false;
 
+    self._acknowledgeAnswer(targetMid, true, null);
     self._handleNegotiationStats('set_answer', targetMid, answer, true);
     self._trigger('handshakeProgress', self.HANDSHAKE_PROGRESS.ANSWER, targetMid);
     self._addIceCandidateFromQueue(targetMid);
@@ -1793,6 +1794,7 @@ Skylink.prototype._answerHandler = function(message) {
   };
 
   var onErrorCbFn = function(error) {
+    self._acknowledgeAnswer(targetMid, false, error);
     self._handleNegotiationStats('error_set_answer', targetMid, answer, true, error);
     self._trigger('handshakeProgress', self.HANDSHAKE_PROGRESS.ERROR, targetMid, error);
 
@@ -2037,3 +2039,29 @@ Skylink.prototype._isLowerThanVersion = function (agentVer, requiredVer) {
 
   return false;
 };
+
+/**
+ * Function that sends a SIG_MESSAGE_TYPE.ANSWER_ACK message to MCU to denote that SDP negotiation has completed (either with success or error)
+ * @method _acknowledgeAnswer
+ * @private
+ * @for Skylink
+ * @since 1.0.0
+ */
+Skylink.prototype._acknowledgeAnswer = function (targetMid, isSuccess, error) {
+  var self = this;
+  if (self._hasMCU) {
+    var statsStateKey = isSuccess ? 'set_answer_ack' : 'error_set_answer_ack';
+    var answerAckMessage = {
+      rid: self._room.id,
+      mid: self._user.sid,
+      target: targetMid,
+      success: isSuccess,
+      type: self._SIG_MESSAGE_TYPE.ANSWER_ACK,
+    };
+    self._sendChannelMessage(answerAckMessage);
+    log.debug(['MCU', 'Remote Description', null, 'Answer acknowledgement message sent to MCU via SIG. Message body -->'], answerAckMessage);
+    self._handleNegotiationStats(statsStateKey, targetMid, answerAckMessage, true, error);
+  }
+  return false;
+};
+


### PR DESCRIPTION
**Purpose of this PR:**

To support new MCU with JS SDK, MCU needs to be notified when SDK clients have completed the SDP negotiation process i.e. successfully/unsuccessfully `setRemoteDescription` in `answerHandler`. To enable this, a new `SIG_MESSAGE_TYPE` is created `answerAck` to be sent to MCU.
- Created a function `acknowledgeAnswer`
- Calling `acknowledgeAnswer` in `answerHandler` success and failure callbacks with respective parameters.
- Message is sent only if MCU is in the room (target is MCU).


See [ESS-1454](https://jira.temasys.com.sg/browse/ESS-1454) for more details. 