### PR TITLE
ESS-1458: Increment peerPriorityWeight when offering

### DIFF
--- a/source/peer-connection.js
+++ b/source/peer-connection.js
@@ -1583,6 +1583,7 @@ Skylink.prototype._restartPeerConnection = function (peerId, doIceRestart, bwOpt
 
     self._peerEndOfCandidatesCounter[peerId] = self._peerEndOfCandidatesCounter[peerId] || {};
     self._peerEndOfCandidatesCounter[peerId].len = 0;
+    self._setGreatestPeerPriorityWeight();
     self._sendChannelMessage(restartMsg);
     self._handleNegotiationStats('restart', peerId, restartMsg, false);
     self._trigger('peerRestart', peerId, self.getPeerInfo(peerId), true, doIceRestart === true);

--- a/source/peer-data.js
+++ b/source/peer-data.js
@@ -749,3 +749,29 @@ Skylink.prototype._getUserInfo = function(peerId) {
   delete userInfo.settings.data;
   return userInfo;
 };
+
+/**
+ * Iterates through all connected peers to find the greatest peerPriorityWeight and sets the current users peerPriorityWeight to max.
+ * @method _setGreatestPeerPriorityWeight
+ * @private
+ * @for Skylink
+ * @since 1.0.0
+ */
+Skylink.prototype._setGreatestPeerPriorityWeight = function() {
+  var self = this;
+  var peerInfoKeys = Object.keys(self._peerInformations);
+  var selfPriorityWeight = self._peerPriorityWeight;
+
+  var maxPeerPriority = selfPriorityWeight;
+  for (var i = 0; i < peerInfoKeys.length; i++) {
+    var peerInformation = self._peerInformations[peerInfoKeys[i]];
+    var priorityWeight = peerInformation.config.priorityWeight;
+
+    if (priorityWeight > maxPeerPriority) {
+      maxPeerPriority = priorityWeight;
+    }
+  }
+
+  self._peerPriorityWeight = maxPeerPriority + 1;
+  log.debug('Users priorityWeight is set to -->', maxPeerPriority);
+};


### PR DESCRIPTION
**Purpose of this PR:**

For the peer who wants to initiate a restart (renegotiation), it needs to have the greatest peerPriorityWeight so that he is the offerer and is able to create required transceivers and update the offer SDP. 
- Created a new private method `setGreatestPeerPriorityWeight` 
- Calling `setGreatestPeerPriorityWeight` from `restartPeerConnection` before sending the `restart` SIG message

See [ESS-1458](https://jira.temasys.com.sg/browse/ESS-1458) for more details. 