### PR TITLE
ESS-1530: Quality statistics gathering - enforce ClientId is consistent across a session in SDK

### DIFF
--- a/source/skylink-stats.js
+++ b/source/skylink-stats.js
@@ -15,7 +15,7 @@ Skylink.prototype._postStats = function (endpoint, params) {
     else{
       requestBody = params;
     }
-    requestBody.client_id = ((self._user && self._user.uid) || 'dummy') + '_' + self._statIdRandom;
+    requestBody.client_id = self._clientId;
     requestBody.app_key = self._initOptions.appKey;
     requestBody.timestamp = (new Date()).toISOString();
 
@@ -45,6 +45,7 @@ Skylink.prototype._handleClientStats = function() {
   var statsObject = {
     username: (self._user && self._user.uid) || null,
     sdk_name: 'web',
+    room_id: self._room ? self._room.id : self._selectedRoom,
     sdk_version: self.VERSION,
     agent_name: AdapterJS.webrtcDetectedBrowser,
     agent_version: AdapterJS.webrtcDetectedVersion,

--- a/source/template/header.js
+++ b/source/template/header.js
@@ -859,12 +859,12 @@ function Skylink() {
 
   /**
    * Stores the unique random number used for generating the "client_id".
-   * @attribute _statIdRandom
+   * @attribute _clientId
    * @type Number
    * @private
    * @for Skylink
    * @since 0.6.31
    */
-  this._statIdRandom = Date.now() + Math.floor(Math.random() * 100000000);
+  this._clientId = this.generateUUID();
 
 }


### PR DESCRIPTION
**Purpose of this PR:**

To make sure that `clientID` is not overwritten by `userID` and stays consistent in a session. Also includes some internal code clean up and refactoring around report errors to statistics API.

See [ESS-1530](https://jira.temasys.com.sg/browse/ESS-1530) for more details. 