### PR TITLE
ESS-1586: Populate transceiverIdPeerIdMap from the offer

### DIFF
--- a/source/socket-message.js
+++ b/source/socket-message.js
@@ -1480,6 +1480,10 @@ Skylink.prototype._offerHandler = function(message) {
     sdp: self._hasMCU ? message.sdp.replace(/\r\n/g, '\n').split('\n').join('\r\n') : message.sdp
   };
 
+  if (targetMid === 'MCU') {
+    self._transceiverIdPeerIdMap = message.transceiverIdPeerIdMap || {};
+  }
+
   self._handleNegotiationStats('offer', targetMid, offer, true);
 
   if (!pc) {


### PR DESCRIPTION
**Purpose of this PR:**

As new MCU now sends offers also, the JS SDK needs to replace the `transceiverIdPeerIdMap` in `_offerHandler`. This will keep the map to latest value, when and if MCU becomes the offerer.

See [ESS-1586](https://jira.temasys.com.sg/browse/ESS-1586) for more details. 