### PR TITLE
Microsoft Edge - HTTP 206 Partial Content Issue

### DIFF
--- a/source/stream-media.js
+++ b/source/stream-media.js
@@ -1892,8 +1892,7 @@ Skylink.prototype._parseStreamTracksInfo = function (streamKey, callback) {
   	}
   	self._streams[streamKey].tracks.video.width = videoElement.videoWidth;
   	self._streams[streamKey].tracks.video.height = videoElement.videoHeight;
-
-  	videoElement.src = '';
+  	
   	videoElement.srcObject = null;
   	callback();
   };


### PR DESCRIPTION
**Purpose of this PR:**

Microsoft Edge send a Range Request `HTTP code 206` because of a line in function `parseStreamTracksInfo` at line https://github.com/Temasys/SkylinkJS/blob/0b7bcfac9ae6249786ebe8da397c9e92871dc5fa/source/stream-media.js#L1896
This line needs to be commented out to avoid Edge sending the 206 request.

See [ESS-1588](https://jira.temasys.com.sg/browse/ESS-1588) for more details. 