### PR TITLE
ESS-1590: P2P and New MCU - Remove restarting logic from SDK

### DIFF
--- a/source/peer-connection.js
+++ b/source/peer-connection.js
@@ -2104,7 +2104,7 @@ Skylink.prototype._restartMCUConnection = function(callback, doIceRestart, bwOpt
 
     log.log([peerId, 'RTCPeerConnection', null, 'Sending restart message to signaling server ->'], restartMsg);
 
-    self._sendChannelMessage(restartMsg);
+    self._doOffer('MCU', doIceRestart, restartMsg);
     self._handleNegotiationStats('restart', peerId, restartMsg, false);
   };
 
@@ -2130,24 +2130,27 @@ Skylink.prototype._restartMCUConnection = function(callback, doIceRestart, bwOpt
     }
   }
 
-  for (var i = 0; i < listOfPeers.length; i++) {
-    if (!self._peerConnections[listOfPeers[i]]) {
-      var error = 'Peer connection with peer does not exists. Unable to restart';
-      log.error([listOfPeers[i], 'PeerConnection', null, error]);
-      listOfPeerRestartErrors[listOfPeers[i]] = new Error(error);
-      continue;
-    }
 
-    if (listOfPeers[i] !== 'MCU') {
-      self._trigger('peerRestart', listOfPeers[i], self.getPeerInfo(listOfPeers[i]), true, false);
+  // Below commented since with new MCU only peer connected is MCU
 
-      if (!self._initOptions.mcuUseRenegoRestart) {
-        sendRestartMsgFn(listOfPeers[i]);
-      }
-    }
-  }
+  // for (var i = 0; i < listOfPeers.length; i++) {
+  //   if (!self._peerConnections[listOfPeers[i]]) {
+  //     var error = 'Peer connection with peer does not exists. Unable to restart';
+  //     log.error([listOfPeers[i], 'PeerConnection', null, error]);
+  //     listOfPeerRestartErrors[listOfPeers[i]] = new Error(error);
+  //     continue;
+  //   }
+  //
+  //   if (listOfPeers[i] !== 'MCU') {
+  //     self._trigger('peerRestart', listOfPeers[i], self.getPeerInfo(listOfPeers[i]), true, false);
+  //
+  //     if (!self._initOptions.mcuUseRenegoRestart) {
+  //       sendRestartMsgFn(listOfPeers[i]);
+  //     }
+  //   }
+  // }
 
-  self._trigger('serverPeerRestart', 'MCU', self.SERVER_PEER_TYPE.MCU);
+  // self._trigger('serverPeerRestart', 'MCU', self.SERVER_PEER_TYPE.MCU);
 
   if (self._initOptions.mcuUseRenegoRestart) {
     self._peerEndOfCandidatesCounter.MCU = self._peerEndOfCandidatesCounter.MCU || {};

--- a/source/peer-connection.js
+++ b/source/peer-connection.js
@@ -1584,8 +1584,8 @@ Skylink.prototype._restartPeerConnection = function (peerId, doIceRestart, bwOpt
     self._peerEndOfCandidatesCounter[peerId] = self._peerEndOfCandidatesCounter[peerId] || {};
     self._peerEndOfCandidatesCounter[peerId].len = 0;
     self._doOffer(peerId, doIceRestart, restartMsg);
-    self._handleNegotiationStats('restart', peerId, restartMsg, false);
-    self._trigger('peerRestart', peerId, self.getPeerInfo(peerId), true, doIceRestart === true);
+    //self._handleNegotiationStats('restart', peerId, restartMsg, false);
+    //self._trigger('peerRestart', peerId, self.getPeerInfo(peerId), true, doIceRestart === true);
 
     if (typeof callback === 'function') {
       log.debug([peerId, 'RTCPeerConnection', null, 'Firing restart callback']);
@@ -2102,10 +2102,10 @@ Skylink.prototype._restartMCUConnection = function(callback, doIceRestart, bwOpt
       restartMsg.parentId = self._parentId;
     }
 
-    log.log([peerId, 'RTCPeerConnection', null, 'Sending restart message to signaling server ->'], restartMsg);
+    // log.log([peerId, 'RTCPeerConnection', null, 'Sending restart message to signaling server ->'], restartMsg);
 
     self._doOffer('MCU', doIceRestart, restartMsg);
-    self._handleNegotiationStats('restart', peerId, restartMsg, false);
+    //self._handleNegotiationStats('restart', peerId, restartMsg, false);
   };
 
   // Toggle the main bandwidth options.

--- a/source/peer-connection.js
+++ b/source/peer-connection.js
@@ -1583,7 +1583,7 @@ Skylink.prototype._restartPeerConnection = function (peerId, doIceRestart, bwOpt
 
     self._peerEndOfCandidatesCounter[peerId] = self._peerEndOfCandidatesCounter[peerId] || {};
     self._peerEndOfCandidatesCounter[peerId].len = 0;
-    self._sendChannelMessage(restartMsg);
+    self._doOffer(peerId, doIceRestart, restartMsg);
     self._handleNegotiationStats('restart', peerId, restartMsg, false);
     self._trigger('peerRestart', peerId, self.getPeerInfo(peerId), true, doIceRestart === true);
 

--- a/source/socket-message.js
+++ b/source/socket-message.js
@@ -1733,15 +1733,15 @@ Skylink.prototype._answerHandler = function(message) {
     return;
   }*/
 
-  // answer.sdp = self._removeSDPFilteredCandidates(targetMid, answer);
-  // answer.sdp = self._setSDPCodec(targetMid, answer);
-  // answer.sdp = self._setSDPBitrate(targetMid, answer);
-  // answer.sdp = self._setSDPCodecParams(targetMid, answer);
-  // answer.sdp = self._removeSDPCodecs(targetMid, answer);
-  // answer.sdp = self._removeSDPREMBPackets(targetMid, answer);
-  // answer.sdp = self._handleSDPConnectionSettings(targetMid, answer, 'remote');
-  // answer.sdp = self._removeSDPUnknownAptRtx(targetMid, answer);
-  // answer.sdp = self._setSCTPport(targetMid, answer);
+  answer.sdp = self._removeSDPFilteredCandidates(targetMid, answer);
+  answer.sdp = self._setSDPCodec(targetMid, answer);
+  answer.sdp = self._setSDPBitrate(targetMid, answer);
+  answer.sdp = self._setSDPCodecParams(targetMid, answer);
+  answer.sdp = self._removeSDPCodecs(targetMid, answer);
+  answer.sdp = self._removeSDPREMBPackets(targetMid, answer);
+  answer.sdp = self._handleSDPConnectionSettings(targetMid, answer, 'remote');
+  answer.sdp = self._removeSDPUnknownAptRtx(targetMid, answer);
+  answer.sdp = self._setSCTPport(targetMid, answer);
 
   log.log([targetMid, 'RTCSessionDescription', message.type, 'Updated remote answer ->'], answer.sdp);
 
@@ -1771,7 +1771,7 @@ Skylink.prototype._answerHandler = function(message) {
     self._trigger('peerUpdated', targetMid, self.getPeerInfo(targetMid), false);
   }
 
-  // self._parseSDPMediaStreamIDs(targetMid, answer);
+  self._parseSDPMediaStreamIDs(targetMid, answer);
 
 
   var onSuccessCbFn = function() {


### PR DESCRIPTION
**Purpose of this PR:**

New MCU and P2P: Removing the logic for restart messages in 1.x SDK. Any peer who wants to renegotiate will just offer instead of restarting. The offer message also contains the same signature as that of restart message.

See [ESS-1590](https://jira.temasys.com.sg/browse/ESS-1590) for more details. 