### PR TITLE
ESS-1597: New MCU Targeted Enter Messages

### DIFF
--- a/source/socket-message.js
+++ b/source/socket-message.js
@@ -552,6 +552,10 @@ Skylink.prototype._approachEventHandler = function(message){
     enterMsg.parentId = self._parentId;
   }
 
+  if (self._hasMCU) {
+    enterMsg.target = 'MCU';
+  }
+
   self._sendChannelMessage(enterMsg);
   self._handleSessionStats(enterMsg);
 };
@@ -941,6 +945,10 @@ Skylink.prototype._inRoomHandler = function(message) {
 
   if (self._parentId) {
     enterMsg.parentId = self._parentId;
+  }
+
+  if (self._hasMCU) {
+    enterMsg.target = 'MCU';
   }
 
   self._sendChannelMessage(enterMsg);


### PR DESCRIPTION
**Purpose of this PR:**

Outgoing `Enter Messages` should be targeted to `MCU` if `MCU` is in the room to facilitate broadcasting of `Enter Messages` to other Peers.

See [ESS-1597](https://jira.temasys.com.sg/browse/ESS-1597) for more details. 