### PR TITLE
ESS-1602: Firefox DTLS issue fixes

### DIFF
--- a/source/peer-handshake.js
+++ b/source/peer-handshake.js
@@ -127,6 +127,12 @@ Skylink.prototype._doAnswer = function(targetMid) {
   var onSuccessCbFn = function(answer) {
     log.debug([targetMid, null, null, 'Created answer'], answer);
     self._handleNegotiationStats('create_answer', targetMid, answer, false);
+
+    if (AdapterJS.webrtcDetectedBrowser === 'firefox') {
+      self._setOriginalDTLSRole(answer, false);
+      answer.sdp = self._modifyDTLSRole(answer);
+    }
+
     self._setLocalAndSendMessage(targetMid, answer);
   };
 

--- a/source/socket-message.js
+++ b/source/socket-message.js
@@ -1587,6 +1587,10 @@ Skylink.prototype._offerHandler = function(message) {
     });
   };
 
+  if (self.getPeerInfo(targetMid).agent.name === 'edge' && offer.sdp[offer.sdp.length - 1] !== '\n' && offer.sdp[offer.sdp.length - 2] !== '\r') {
+    offer.sdp = offer.sdp + '\r\n';
+  }
+
   pc.setRemoteDescription(new RTCSessionDescription(offer), onSuccessCbFn, onErrorCbFn);
 };
 

--- a/source/socket-message.js
+++ b/source/socket-message.js
@@ -1755,6 +1755,10 @@ Skylink.prototype._answerHandler = function(message) {
   answer.sdp = self._removeSDPUnknownAptRtx(targetMid, answer);
   answer.sdp = self._setSCTPport(targetMid, answer);
 
+  if (AdapterJS.webrtcDetectedBrowser === 'firefox') {
+    self._setOriginalDTLSRole(answer, true);
+  }
+
   log.log([targetMid, 'RTCSessionDescription', message.type, 'Updated remote answer ->'], answer.sdp);
 
   // This should be the state after offer is received. or even after negotiation is successful

--- a/source/stream-media.js
+++ b/source/stream-media.js
@@ -1220,12 +1220,35 @@ Skylink.prototype.shareScreen = function (enableAudio, mediaSource, callback) {
       if (self._inRoom) {
         self._trigger('incomingStream', self._user.sid, stream, true, self.getPeerInfo(), true, stream.id || stream.label);
         self._trigger('peerUpdated', self._user.sid, self.getPeerInfo(), true);
+        var shouldRenegotiate = true;
 
-        var gDMVideoTrack = stream.getVideoTracks()[0];
-        var gUMVideoTrack = self._streams.userMedia.stream.getVideoTracks()[0];
+        if (self._streams.userMedia && self._streams.userMedia.stream && Array.isArray(self._streams.userMedia.stream.getVideoTracks()) && self._streams.userMedia.stream.getVideoTracks().length) {
+          shouldRenegotiate = false;
+        }
 
-        self._replaceTrack(gUMVideoTrack.id, gDMVideoTrack);
-
+        if (shouldRenegotiate) {
+          if (Object.keys(self._peerConnections).length > 0 || self._hasMCU) {
+            stream.wasNegotiated = true;
+            self._refreshPeerConnection(Object.keys(self._peerConnections), false, {}, function (err, success) {
+              if (err) {
+                log.error('Failed refreshing connections for shareScreen() ->', err);
+                if (typeof callback === 'function') {
+                  callback(new Error('Failed refreshing connections.'), null);
+                }
+                return;
+              }
+              if (typeof callback === 'function') {
+                callback(null, stream);
+              }
+            });
+          } else if (typeof callback === 'function') {
+            callback(null, stream);
+          }
+        } else {
+          var gDMVideoTrack = stream.getVideoTracks()[0];
+          var gUMVideoTrack = self._streams.userMedia.stream.getVideoTracks()[0];
+          self._replaceTrack(gUMVideoTrack.id, gDMVideoTrack);
+        }
       } else if (typeof callback === 'function') {
         callback(null, stream);
       }
@@ -1376,12 +1399,15 @@ Skylink.prototype.stopScreen = function () {
           false, self._streams.userMedia.stream.id || self._streams.userMedia.stream.label);
         self._trigger('peerUpdated', self._user.sid, self.getPeerInfo(), true);
       }
-      //this._refreshPeerConnection(Object.keys(this._peerConnections), {}, false);
 
-      var gDMVideoTrack = self._streams.screenshare.stream.getVideoTracks()[0];
-      var gUMVideoTrack = self._streams.userMedia.stream.getVideoTracks()[0];
+      if (self._streams.screenshare.stream.wasNegotiated === true) {
+        this._refreshPeerConnection(Object.keys(this._peerConnections), {}, false);
+      } else {
+        var gDMVideoTrack = self._streams.screenshare.stream.getVideoTracks()[0];
+        var gUMVideoTrack = self._streams.userMedia.stream.getVideoTracks()[0];
 
-      self._replaceTrack(gDMVideoTrack.id, gUMVideoTrack);
+        self._replaceTrack(gDMVideoTrack.id, gUMVideoTrack);
+      }
     }
     self._stopStreams({
       screenshare: true

--- a/source/stream-media.js
+++ b/source/stream-media.js
@@ -1226,6 +1226,10 @@ Skylink.prototype.shareScreen = function (enableAudio, mediaSource, callback) {
           shouldRenegotiate = false;
         }
 
+        if (AdapterJS.webrtcDetectedBrowser === 'edge') {
+          shouldRenegotiate = true;
+        }
+
         if (shouldRenegotiate) {
           if (Object.keys(self._peerConnections).length > 0 || self._hasMCU) {
             stream.wasNegotiated = true;
@@ -1332,7 +1336,13 @@ Skylink.prototype.shareScreen = function (enableAudio, mediaSource, callback) {
       }
 
       AdapterJS.webRTCReady(function () {
-        if (typeof navigator.mediaDevices.getDisplayMedia === 'function') {
+        if (AdapterJS.webrtcDetectedBrowser === 'edge' && typeof navigator.getDisplayMedia === 'function') {
+          navigator.getDisplayMedia(settings.getUserMediaSettings).then(function(stream) {
+            onSuccessCbFn(stream);
+          }).catch(function(err) {
+            onErrorCbFn(err);
+          });
+        } else if (typeof navigator.mediaDevices.getDisplayMedia === 'function') {
           navigator.mediaDevices.getDisplayMedia(settings.getUserMediaSettings).then(function(stream) {
             onSuccessCbFn(stream);
           }).catch(function(err) {

--- a/source/template/header.js
+++ b/source/template/header.js
@@ -898,4 +898,13 @@ function Skylink() {
    */
   this._currentRequestedTracks = { audio: 0, video: 0 };
 
+  /**
+   * Originally negotiated DTLS role of this peer.
+   * @attribute _originalDTLSRole
+   * @type String
+   * @private
+   * @for Skylink
+   * @since 1.0.0
+   */
+  this._originalDTLSRole = null;
 }


### PR DESCRIPTION
**Purpose of this PR:**

1. Firefox incorrectly generates `"a=setup"` line in answer when negotiated DTLS role is `"passive"`. This PR includes a fix to ensure that renegotiation and outgoing answer from Firefox have the correct role in `SDP`.

Original Bugzilla(#1240897): https://bugzilla.mozilla.org/show_bug.cgi?id=1240897
To be released: 9th July, 2019

2. Added Case for screenshare: When screen-sharing, if video track's `RTCRTPSender` is not available, `replaceTrack` is not possible. Hence, SDK should renegotiate.

3. Added case for Microsoft Edge in unified-mode - `getDisplayMedia` is available at `navigator.getDisplayMedia`

4. Fix for: MS Edge when offering does not add an `\r\n` to the end of the SDP 

See [ESS-1602](https://jira.temasys.com.sg/browse/ESS-1602) for more details. 