### PR TITLE
ESS-1457: Using addTrack and removeTrack while adding localMediaStreams

### DIFF
--- a/source/stream-media.js
+++ b/source/stream-media.js
@@ -2252,31 +2252,22 @@ Skylink.prototype._addLocalMediaStreams = function(peerId) {
         // Updates the streams accordingly
         var updateStreamFn = function (updatedStream) {
           if (updatedStream ? (pc.localStreamId ? updatedStream.id !== pc.localStreamId : true) : true) {
-            if (AdapterJS.webrtcDetectedBrowser === 'edge' && !(self._initOptions.useEdgeWebRTC && window.msRTCPeerConnection)) {
-              pc.getSenders().forEach(function (sender) {
-                pc.removeTrack(sender);
-              });
-            } else {
-              pc.getLocalStreams().forEach(function (stream) {
-                pc.removeStream(stream);
-              });
-            }
+
+            pc.getSenders().forEach(function (sender) {
+              pc.removeTrack(sender);
+            });
 
             if (!offerToReceiveAudio && !offerToReceiveVideo) {
               return;
             }
 
             if (updatedStream) {
-              if (AdapterJS.webrtcDetectedBrowser === 'edge' && !(self._initOptions.useEdgeWebRTC && window.msRTCPeerConnection)) {
-                updatedStream.getTracks().forEach(function (track) {
-                  if ((track.kind === 'audio' && !offerToReceiveAudio) || (track.kind === 'video' && !offerToReceiveVideo)) {
-                    return;
-                  }
-                  pc.addTrack(track, updatedStream);
-                });
-              } else {
-                pc.addStream(updatedStream);
-              }
+              updatedStream.getTracks().forEach(function (track) {
+                if ((track.kind === 'audio' && !offerToReceiveAudio) || (track.kind === 'video' && !offerToReceiveVideo)) {
+                  return;
+                }
+                pc.addTrack(track, updatedStream);
+              });
 
               pc.localStreamId = updatedStream.id || updatedStream.label;
               pc.localStream = updatedStream;


### PR DESCRIPTION
**Purpose of this PR:**

To support new MCU and P2P with JS SDK under the new unified plan in chrome, deprecated methods for stream/track manipulation need to be removed and we need to make sure we are using `MediaStreamTrack` APIs to add/remove/replace tracks.
- `addLocalMediaStreams` updated to always use `removeTrack(RTCRTPSender)` to remove a track
- `addLocalMediaStreams` updated to always use `addTrack(MST, ...stream)` to add a track and optionally associate with a `MediaStream`

See [ESS-1457](https://jira.temasys.com.sg/browse/ESS-1457) for more details. 