### PR TITLE
Removed Video Element

### DIFF
--- a/source/stream-media.js
+++ b/source/stream-media.js
@@ -1964,33 +1964,35 @@ Skylink.prototype._parseStreamTracksInfo = function (streamKey, callback) {
 		height: null
 	};
 
-	// Append the stream to a dummy <video> element to retrieve the resolution width and height.
-  var videoElement = document.createElement('video');
-  videoElement.autoplay = true;
-  // Mute the audio of the <video> element to prevent feedback.
-  videoElement.muted = true;
-  videoElement.volume = 0;
+  callback();
 
-  var onVideoLoaded = function () {
-  	if (!self._streams[streamKey]) {
-  		return;
-  	}
-  	self._streams[streamKey].tracks.video.width = videoElement.videoWidth;
-  	self._streams[streamKey].tracks.video.height = videoElement.videoHeight;
-  	
-  	videoElement.srcObject = null;
-  	callback();
-  };
-
-  // Because the plugin does not support the "loadeddata" event.
-  if (AdapterJS.webrtcDetectedType === 'plugin') {
-    setTimeout(onVideoLoaded, 1500);
-
-  } else {
-    videoElement.addEventListener('loadeddata', onVideoLoaded);
-  }
-
-  AdapterJS.attachMediaStream(videoElement, stream);
+  // // Append the stream to a dummy <video> element to retrieve the resolution width and height.
+  // var videoElement = document.createElement('video');
+  // videoElement.autoplay = true;
+  // // Mute the audio of the <video> element to prevent feedback.
+  // //videoElement.muted = true;
+  // videoElement.volume = 0;
+  //
+  // var onVideoLoaded = function () {
+  // 	if (!self._streams[streamKey]) {
+  // 		return;
+  // 	}
+  // 	self._streams[streamKey].tracks.video.width = videoElement.videoWidth;
+  // 	self._streams[streamKey].tracks.video.height = videoElement.videoHeight;
+  //
+  // 	videoElement.srcObject = null;
+  // 	callback();
+  // };
+  //
+  // // Because the plugin does not support the "loadeddata" event.
+  // if (AdapterJS.webrtcDetectedType === 'plugin') {
+  //   setTimeout(onVideoLoaded, 1500);
+  //
+  // } else {
+  //   videoElement.addEventListener('loadeddata', onVideoLoaded);
+  // }
+  //
+  // AdapterJS.attachMediaStream(videoElement, stream);
 }
 
 /**


### PR DESCRIPTION
Removed Video Element from the _parseStreamTracksInfo as it was muting video. Possible impact on plugins. But plugin is not supported in this release.