### PR TITLE
New MCU - SDK should add empty video transceiver

### DIFF
--- a/source/peer-connection.js
+++ b/source/peer-connection.js
@@ -1837,6 +1837,11 @@ Skylink.prototype._createPeerConnection = function(targetMid, isScreenSharing, c
   self._peerBandwidth[targetMid] = {};
   var bandwidth = null;
 
+  if (targetMid === 'MCU') {
+    log.info('Creating an empty transceiver of kind video with MCU');
+    pc.addTransceiver('video');
+  }
+
   // callbacks
   // standard not implemented: onnegotiationneeded,
   pc.ondatachannel = function(event) {
@@ -2302,47 +2307,6 @@ Skylink.prototype._signalingEndOfCandidates = function(targetMid) {
     } catch (error) {
       log.error([targetMid, 'RTCPeerConnection', null, 'Failed signaling end-of-candidates ->'], error);
     }
-  }
-};
-
-/**
- * Function that compares trackCount sent by MCU and decides wether to add new Transceivers based on count differences
- * @method _compareTrackCounts
- * @param {String} targetMid
- * @private
- */
-Skylink.prototype._compareTrackCounts = function (targetMid) {
-  var self = this;
-  var pc = self._peerConnections[targetMid];
-
-  if (pc && typeof pc.getTransceivers === 'function') {
-    var transceivers = pc.getTransceivers();
-    var transceiverTypeCount = {
-      audio: 0,
-      video: 0
-    };
-
-    var checkDiffAndAddTransceivers = function (kind, requestedKindCount, actualKindCount, peerConnection) {
-      if (requestedKindCount > actualKindCount) {
-        var diff = requestedKindCount - actualKindCount;
-        while (diff) {
-          peerConnection.addTransceiver(kind);
-          diff = diff - 1;
-        }
-      }
-    };
-
-    if (transceivers && transceivers.length) {
-      for (var i = 0; i < transceivers.length; i++) {
-        if (transceivers[i] && transceivers[i].receiver && transceivers[i].receiver.track) {
-          var kind = transceivers[i].receiver.track.kind;
-          transceiverTypeCount[kind] += 1;
-        }
-      }
-    }
-
-    checkDiffAndAddTransceivers('video', self._currentRequestedTracks['video'], transceiverTypeCount.video, pc);
-    checkDiffAndAddTransceivers('audio', self._currentRequestedTracks['audio'], transceiverTypeCount.audio, pc);
   }
 };
 

--- a/source/peer-handshake.js
+++ b/source/peer-handshake.js
@@ -34,7 +34,6 @@ Skylink.prototype._doOffer = function(targetMid, iceRestart, mergeMessageWithOff
 
   // Add stream only at offer/answer end
   if (!self._hasMCU || targetMid === 'MCU') {
-    //self._compareTrackCounts(targetMid);
     self._addLocalMediaStreams(targetMid);
   }
 


### PR DESCRIPTION
**Purpose of this PR:**

The new MCU needs to extract video codecs from the `SDP` - to enable that, SDK needs to add an empty video `transceiver` after creating a `PeerConnection` with the new MCU.

This PR also removes the no longer needed `_compareTrackCounts` function's definition and usage in the SDK

See [ESS-1620](https://jira.temasys.com.sg/browse/ESS-1620) for more details. 