### PR TITLE
ESS-1621: Updates to shareScreen error logging and default throttleInterval

### DIFF
--- a/source/room-init.js
+++ b/source/room-init.js
@@ -536,7 +536,7 @@ Skylink.prototype.init = function(_options, _callback) {
 
   // `init({ throttleIntervals: { shareScreen: 10000 } })`
   options.throttleIntervals.shareScreen = typeof options.throttleIntervals.shareScreen === 'number' ?
-    options.throttleIntervals.shareScreen : 10000;
+    options.throttleIntervals.shareScreen : 1000;
 
   // `init({ throttleIntervals: { refreshConnection: 5000 } })`
   options.throttleIntervals.refreshConnection = typeof options.throttleIntervals.refreshConnection === 'number' ?

--- a/source/stream-media.js
+++ b/source/stream-media.js
@@ -2182,7 +2182,7 @@ Skylink.prototype._onStreamAccessError = function(error, settings, isScreenShari
     return;
   }
   if (isScreenSharing) {
-    log.error('Failed retrieving screensharing Stream ->', error);
+    log.warn('Failed retrieving screensharing Stream ->', error);
   } else {
     log.error('Failed retrieving camera Stream ->', error);
   }


### PR DESCRIPTION
**Purpose of this PR:**

When a user cancels out of Screen Sharing dialogue box of the browser, the "error" reported needs to be changed to `WARN` from `ERROR`. 

Also, the `throttleInterval` of `shareScreen` function is reduced from `10000ms` to `1000ms`

See [ESS-1621](https://jira.temasys.com.sg/browse/ESS-1621) for more details. 