### PR TITLE
ESS-1614 | Add roomSize initOption and pass to API Server

### DIFF
--- a/source/constants.js
+++ b/source/constants.js
@@ -1525,3 +1525,26 @@ Skylink.prototype.RTMP_STATE = {
   STOP: 1,
   ERROR: -1
 };
+
+/**
+ * The different sizes of room that can be passed to API server to invoke a MCU Container [MCU ONLY OPTION].
+ * @attribute ROOM_SIZE
+ * @param {string} SMALL <small>Value <code>small</code></small>
+ *   The size of the room as small
+ * @param {string} MEDIUM <small>Value <code>medium</code></small>
+ *   The size of the room as medium
+ * @param {string} LARGE <small>Value <code>-large</code></small>
+ *   The size of the room as large
+ * @param {string} EXTRA_LARGE <small>Value <code>-extraLarge</code></small>
+ *   The size of the room as extra large
+ * @type JSON
+ * @beta
+ * @for Skylink
+ * @since 0.6.34
+ */
+Skylink.prototype.ROOM_SIZE = {
+  SMALL: 'small',
+  MEDIUM: 'medium',
+  LARGE: 'large',
+  EXTRA_LARGE: 'extraLarge'
+};

--- a/source/room-connection.js
+++ b/source/room-connection.js
@@ -352,7 +352,7 @@ Skylink.prototype.joinRoom = function(room, options, callback) {
       return;
     }
 
-    self._initSelectedRoom(selectedRoom, function(initError, initSuccess) {
+    self._initSelectedRoom(selectedRoom, true, function(initError, initSuccess) {
       if (initError) {
         resolveAsErrorFn(initError.error, self._selectedRoom, self._readyState);
         return;

--- a/source/room-init.js
+++ b/source/room-init.js
@@ -697,6 +697,8 @@ Skylink.prototype.init = function(_options, _callback) {
     options.filterCandidatesType.relay = false;
   }
 
+  options.roomSize = options.roomSize || self.ROOM_SIZE.SMALL;
+
   self.once('readyStateChange', function () { }, function (state, error) {
     if (state === self.READY_STATE_CHANGE.ERROR) {
       log.error('Failed init() process ->', error);

--- a/source/room-init.js
+++ b/source/room-init.js
@@ -414,6 +414,7 @@ Skylink.prototype.init = function(_options, _callback) {
   var self = this;
   var options = {};
   var callback = function () {};
+  var isCalledFromJoinRoomFn = false;
 
   // `init(function () {})`
   if (typeof _options === 'function'){
@@ -437,6 +438,11 @@ Skylink.prototype.init = function(_options, _callback) {
   // `init(.., function () {})`
   if (typeof _callback === 'function') {
     callback = _callback;
+  }
+
+  if (_options && typeof _options === 'object' && typeof _options.isCalledFromJoinRoomFn === 'boolean') {
+    isCalledFromJoinRoomFn = _options.isCalledFromJoinRoomFn;
+    delete _options.isCalledFromJoinRoomFn;
   }
 
   // `init({ defaultRoom: "xxxxx" })`
@@ -744,7 +750,7 @@ Skylink.prototype.init = function(_options, _callback) {
     self._initOptions.credentials.duration + '?cred=' + self._initOptions.credentials.credentials : '') +
     (self._initOptions.credentials ? '&' : '?') + 'rand=' + Date.now();
 
-  self._loadInfo();
+  self._loadInfo(isCalledFromJoinRoomFn);
 };
 
 /**
@@ -979,7 +985,7 @@ Skylink.prototype._parseInfo = function(info) {
  * @for Skylink
  * @since 0.5.2
  */
-Skylink.prototype._loadInfo = function() {
+Skylink.prototype._loadInfo = function(isCalledFromJoinRoomFn) {
   var self = this;
 
   if (typeof (globals.AdapterJS || window.AdapterJS || {}).webRTCReady !== 'function') {
@@ -1078,7 +1084,9 @@ Skylink.prototype._loadInfo = function() {
       self._readyState = self.READY_STATE_CHANGE.LOADING;
       self._trigger('readyStateChange', self.READY_STATE_CHANGE.LOADING, null, self._selectedRoom);
       self._handleClientStats();
-      self._requestServerInfo('GET', self._path, function(response) {
+
+      var endpoint = isCalledFromJoinRoomFn && self._hasMCU ? self._path + '&room-size=' + self._initOptions.roomSize : self._path;
+      self._requestServerInfo('GET', endpoint, function(response) {
         self._parseInfo(response);
       });
     });
@@ -1092,7 +1100,7 @@ Skylink.prototype._loadInfo = function() {
  * @for Skylink
  * @since 0.5.5
  */
-Skylink.prototype._initSelectedRoom = function(room, callback) {
+Skylink.prototype._initSelectedRoom = function(room, isCalledFromJoinRoomFn, callback) {
   var self = this;
   if (typeof room === 'function' || typeof room === 'undefined') {
     log.error('Invalid room provided. Room:', room);
@@ -1106,6 +1114,8 @@ Skylink.prototype._initSelectedRoom = function(room, callback) {
   if(options.defaultRoom!==room){
     options.defaultRoom = room;
   }
+
+  options.isCalledFromJoinRoomFn = isCalledFromJoinRoomFn;
 
   self.init(options, function (error, success) {
     self._initOptions.defaultRoom = defaultRoom;


### PR DESCRIPTION
**Purpose of this PR:**

A new public config option `roomSize` has been added to convey the approximate number of peers that could join a room. This information is passed to the `API SERVER` via url param `&room_size` to manage and create MCU instances respectively.


See [ESS-1614](https://jira.temasys.com.sg/browse/ESS-1614) for more details. 