### PR TITLE
ESS-1652: Fix URL param for room size

### DIFF
--- a/source/room-init.js
+++ b/source/room-init.js
@@ -1086,7 +1086,7 @@ Skylink.prototype._loadInfo = function(isCalledFromJoinRoomFn) {
       self._trigger('readyStateChange', self.READY_STATE_CHANGE.LOADING, null, self._selectedRoom);
       self._handleClientStats();
 
-      var endpoint = isCalledFromJoinRoomFn && self._hasMCU ? self._path + '&room-size=' + self._initOptions.roomSize : self._path;
+      var endpoint = isCalledFromJoinRoomFn && self._hasMCU ? self._path + '&room_size=' + self._initOptions.roomSize : self._path;
       self._requestServerInfo('GET', endpoint, function(response) {
         self._parseInfo(response);
       });


### PR DESCRIPTION
**Purpose of this PR:**

URL parameter for room size is `room_size`. Current code contains incorrect param name as `room-size`. This PR fixes the said issue.

See [ESS-1652](https://jira.temasys.com.sg/browse/ESS-1652) for more details. 