### PR TITLE
ESS-1632: Offer Buffering and Double Renegotiations

### DIFF
--- a/source/ice-candidate.js
+++ b/source/ice-candidate.js
@@ -244,10 +244,7 @@ Skylink.prototype._addIceCandidate = function (targetMid, canId, candidate) {
     }, null);
 
   if (!(self._peerConnections[targetMid] &&
-    self._peerConnections[targetMid].signalingState !== self.PEER_CONNECTION_STATE.CLOSED &&
-    self._peerConnections[targetMid].remoteDescription &&
-    self._peerConnections[targetMid].remoteDescription.sdp &&
-    self._peerConnections[targetMid].remoteDescription.sdp.indexOf('\r\na=mid:' + candidate.sdpMid + '\r\n') > -1)) {
+    self._peerConnections[targetMid].signalingState !== self.PEER_CONNECTION_STATE.CLOSED)) {
     log.warn([targetMid, 'RTCIceCandidate', canId + ':' + candidateType, 'Dropping ICE candidate ' +
       'as Peer connection does not exists or is closed']);
     self._handleIceCandidateStats('process_failed', targetMid, canId, candidate, 'Peer connection does not exist');

--- a/source/peer-connection.js
+++ b/source/peer-connection.js
@@ -2048,6 +2048,7 @@ Skylink.prototype._createPeerConnection = function(targetMid, isScreenSharing, c
         for (var t = 0; t < tracks.length; t++) {
           if (tracks[t] === senders[s].track) {
             pc.removeTrack(senders[s]);
+            self._removeSenderFromList(targetMid, senders[s]);
           }
         }
       }

--- a/source/peer-connection.js
+++ b/source/peer-connection.js
@@ -1839,7 +1839,9 @@ Skylink.prototype._createPeerConnection = function(targetMid, isScreenSharing, c
 
   if (targetMid === 'MCU') {
     log.info('Creating an empty transceiver of kind video with MCU');
-    pc.addTransceiver('video');
+    if (typeof pc.addTransceiver === 'function') {
+      pc.addTransceiver('video');
+    }
   }
 
   // callbacks

--- a/source/peer-handshake.js
+++ b/source/peer-handshake.js
@@ -226,7 +226,7 @@ Skylink.prototype._setLocalAndSendMessage = function(targetMid, _sessionDescript
     log.debug([targetMid, 'RTCSessionDescription', sessionDescription.type,
       'Local session description has been set ->'], sessionDescription);
 
-    pc.processingLocalSDP = false;
+
 
     self._handleNegotiationStats('set_' + sessionDescription.type, targetMid, sessionDescription, false);
     self._trigger('handshakeProgress', sessionDescription.type, targetMid);
@@ -251,6 +251,8 @@ Skylink.prototype._setLocalAndSendMessage = function(targetMid, _sessionDescript
       rid: self._room.id,
       userInfo: self._getUserInfo(targetMid)
     };
+
+    pc.processingLocalSDP = messageToSend.type === self.HANDSHAKE_PROGRESS.OFFER;
 
     if (sessionDescription.type === self.HANDSHAKE_PROGRESS.OFFER) {
       messageToSend.weight = self._peerPriorityWeight;

--- a/source/peer-handshake.js
+++ b/source/peer-handshake.js
@@ -303,7 +303,6 @@ Skylink.prototype.renegotiateIfNeeded = function (peerId) {
 
   Promise.all(senderGetStatsPromises).then(function(reslovedResults) {
     reslovedResults.forEach(function(reports, senderIndex) {
-      console.log(reports);
       reports.forEach(function(report) {
         if (report && report.ssrc) {
           transmittingSenders[report.ssrc] = pcSenders[senderIndex];

--- a/source/peer-handshake.js
+++ b/source/peer-handshake.js
@@ -32,6 +32,10 @@ Skylink.prototype._doOffer = function(targetMid, iceRestart, mergeMessageWithOff
     voiceActivityDetection: self._voiceActivityDetection
   };
 
+  if (self._hasMCU && typeof pc.addTransceiver !== 'function') {
+    offerConstraints.offerToReceiveVideo = true;
+  }
+
   // Add stream only at offer/answer end
   if (!self._hasMCU || targetMid === 'MCU') {
     self._addLocalMediaStreams(targetMid);

--- a/source/peer-handshake.js
+++ b/source/peer-handshake.js
@@ -290,45 +290,47 @@ Skylink.prototype._setLocalAndSendMessage = function(targetMid, _sessionDescript
 
 Skylink.prototype.renegotiateIfNeeded = function (peerId) {
   var self = this;
-  var peerConnection = self._peerConnections[peerId];
-  var pcSenders = peerConnection.getSenders();
-  var senderGetStatsPromises = [];
-  var savedSenders = self._currentRTCRTPSenders[peerId];
-  var isRenegoNeeded = false;
+  return new Promise(function(resolve, reject) {
+    var peerConnection = self._peerConnections[peerId];
+    var pcSenders = peerConnection.getSenders();
+    var senderGetStatsPromises = [];
+    var savedSenders = self._currentRTCRTPSenders[peerId];
+    var isRenegoNeeded = false;
 
-  pcSenders.forEach(function(pcSender) {
-    senderGetStatsPromises.push(pcSender.getStats());
-  });
-  var transmittingSenders = {};
+    pcSenders.forEach(function(pcSender) {
+      senderGetStatsPromises.push(pcSender.getStats());
+    });
+    var transmittingSenders = {};
 
-  Promise.all(senderGetStatsPromises).then(function(reslovedResults) {
-    reslovedResults.forEach(function(reports, senderIndex) {
-      reports.forEach(function(report) {
-        if (report && report.ssrc) {
-          transmittingSenders[report.ssrc] = pcSenders[senderIndex];
-        }
+    Promise.all(senderGetStatsPromises).then(function(reslovedResults) {
+      reslovedResults.forEach(function(reports, senderIndex) {
+        reports.forEach(function(report) {
+          if (report && report.ssrc) {
+            transmittingSenders[report.ssrc] = pcSenders[senderIndex];
+          }
+        });
       });
+
+      var transmittingSendersKeys = Object.keys(transmittingSenders);
+
+      if (transmittingSendersKeys.length !== savedSenders.length) {
+        isRenegoNeeded = true;
+      } else {
+        var senderMatchedCount = 0;
+        for (var tKey = 0; tKey < transmittingSendersKeys.length; tKey++) {
+          var tSender = transmittingSenders[transmittingSendersKeys[tKey]];
+          for (var sIndex = 0; sIndex < savedSenders.length; sIndex++) {
+            var sSender = savedSenders[sIndex];
+            if (tSender === sSender) {
+              senderMatchedCount++;
+              break;
+            }
+          }
+        }
+        isRenegoNeeded = senderMatchedCount !== transmittingSendersKeys.length;
+      }
+      resolve(isRenegoNeeded);
     });
   });
 
-  var transmittingSendersKeys = Object.keys(transmittingSenders);
-
-  if (transmittingSendersKeys.length !== savedSenders.length) {
-    isRenegoNeeded = true;
-  } else {
-    var senderMatchedCount = 0;
-    for (var tKey = 0; tKey < transmittingSendersKeys.length; tKey++) {
-      var tSender = transmittingSenders[tKey];
-      for (var sIndex = 0; sIndex < savedSenders.length; sIndex++) {
-        var sSender = savedSenders[sIndex];
-        if (tSender === sSender) {
-          senderMatchedCount++;
-          break;
-        }
-      }
-    }
-    isRenegoNeeded = senderMatchedCount !== transmittingSendersKeys.length;
-  }
-
-  return isRenegoNeeded;
 };

--- a/source/peer-handshake.js
+++ b/source/peer-handshake.js
@@ -248,6 +248,10 @@ Skylink.prototype._setLocalAndSendMessage = function(targetMid, _sessionDescript
       userInfo: self._getUserInfo(targetMid)
     };
 
+    if (sessionDescription.type === self.HANDSHAKE_PROGRESS.OFFER) {
+      messageToSend.weight = self._peerPriorityWeight;
+    }
+
     // Merging Restart and Offer messages. The already present keys in offer message will not be overwritten.
     // Only news keys from mergeMessage are added.
     if (mergeMessage && Object.keys(mergeMessage).length) {
@@ -274,5 +278,12 @@ Skylink.prototype._setLocalAndSendMessage = function(targetMid, _sessionDescript
     self._trigger('handshakeProgress', self.HANDSHAKE_PROGRESS.ERROR, targetMid, error);
   };
 
-  pc.setLocalDescription(new RTCSessionDescription(sessionDescription), onSuccessCbFn, onErrorCbFn);
+  if (sessionDescription.type === self.HANDSHAKE_PROGRESS.OFFER) {
+    self._bufferedLocalOffer[targetMid] = sessionDescription;
+    onSuccessCbFn();
+  } else {
+    pc.setLocalDescription(new RTCSessionDescription(sessionDescription), onSuccessCbFn, onErrorCbFn);
+  }
+
+
 };

--- a/source/socket-message.js
+++ b/source/socket-message.js
@@ -1570,6 +1570,7 @@ Skylink.prototype._offerHandler = function(message) {
   }
 
   pc.processingRemoteSDP = true;
+  pc.processingLocalSDP = false;
 
   if (message.userInfo) {
     self._trigger('peerUpdated', targetMid, self.getPeerInfo(targetMid), false);

--- a/source/stream-media.js
+++ b/source/stream-media.js
@@ -2275,25 +2275,6 @@ Skylink.prototype._addLocalMediaStreams = function(peerId) {
                   }
 
                   self._currentRTCRTPSenders[peerId].push(sender);
-
-                  /*if (self._userData.addFake) {
-                    var whiteNoise = function() {
-                      var canvas = Object.assign(document.createElement("canvas"), {width: 320, height: 240});
-                      var ctx = canvas.getContext('2d');
-                      ctx.fillRect(0, 0, canvas.width, canvas.height);
-                      var p = ctx.getImageData(0, 0, canvas.width, canvas.height);
-                      requestAnimationFrame(function draw(){
-                        for (var i = 0; i < p.data.length; i++) {
-                          p.data[i++] = p.data[i++] = p.data[i++] = Math.random() * 255;
-                        }
-                        ctx.putImageData(p, 0, 0);
-                        requestAnimationFrame(draw);
-                      });
-                      return canvas.captureStream(60).getTracks()[0];
-                    }
-                    var _sender = pc.addTrack(whiteNoise(), updatedStream);
-                    self._currentRTCRTsPSenders[peerId].push(_sender);
-                  }*/
                 });
 
               pc.localStreamId = updatedStream.id || updatedStream.label;

--- a/source/stream-media.js
+++ b/source/stream-media.js
@@ -2354,7 +2354,6 @@ Skylink.prototype._handleEndedStreams = function (peerId, checkStreamId) {
 Skylink.prototype._removeSenderFromList = function(peerId, sender) {
   var indexToRemove = -1;
   if (!this._currentRTCRTPSenders[peerId]) {
-    log.warn([peerId, null, null, 'The _currentRTCRTPSenders map for peer does not exist ']);
     return;
   }
   var listOfSenders = this._currentRTCRTPSenders[peerId];

--- a/source/stream-media.js
+++ b/source/stream-media.js
@@ -2256,6 +2256,7 @@ Skylink.prototype._addLocalMediaStreams = function(peerId) {
           if (updatedStream ? (pc.localStreamId ? updatedStream.id !== pc.localStreamId : true) : true) {
             pc.getSenders().forEach(function (sender) {
               pc.removeTrack(sender);
+              self._removeSenderFromList(peerId, sender);
             });
 
             if (!offerToReceiveAudio && !offerToReceiveVideo) {
@@ -2267,7 +2268,32 @@ Skylink.prototype._addLocalMediaStreams = function(peerId) {
                   if ((track.kind === 'audio' && !offerToReceiveAudio) || (track.kind === 'video' && !offerToReceiveVideo)) {
                     return;
                   }
-                  pc.addTrack(track, updatedStream);
+                  var sender = pc.addTrack(track, updatedStream);
+
+                  if (!self._currentRTCRTPSenders[peerId]) {
+                    self._currentRTCRTPSenders[peerId] = [];
+                  }
+
+                  self._currentRTCRTPSenders[peerId].push(sender);
+
+                  /*if (self._userData.addFake) {
+                    var whiteNoise = function() {
+                      var canvas = Object.assign(document.createElement("canvas"), {width: 320, height: 240});
+                      var ctx = canvas.getContext('2d');
+                      ctx.fillRect(0, 0, canvas.width, canvas.height);
+                      var p = ctx.getImageData(0, 0, canvas.width, canvas.height);
+                      requestAnimationFrame(function draw(){
+                        for (var i = 0; i < p.data.length; i++) {
+                          p.data[i++] = p.data[i++] = p.data[i++] = Math.random() * 255;
+                        }
+                        ctx.putImageData(p, 0, 0);
+                        requestAnimationFrame(draw);
+                      });
+                      return canvas.captureStream(60).getTracks()[0];
+                    }
+                    var _sender = pc.addTrack(whiteNoise(), updatedStream);
+                    self._currentRTCRTsPSenders[peerId].push(_sender);
+                  }*/
                 });
 
               pc.localStreamId = updatedStream.id || updatedStream.label;
@@ -2343,3 +2369,24 @@ Skylink.prototype._handleEndedStreams = function (peerId, checkStreamId) {
     }
   }
 };
+
+Skylink.prototype._removeSenderFromList = function(peerId, sender) {
+  var indexToRemove = -1;
+  if (!this._currentRTCRTPSenders[peerId]) {
+    log.warn([peerId, null, null, 'The _currentRTCRTPSenders map for peer does not exist ']);
+    return;
+  }
+  var listOfSenders = this._currentRTCRTPSenders[peerId];
+  for (var i = 0; i < listOfSenders.length; i++) {
+    if (sender === listOfSenders[i]) {
+      indexToRemove = i;
+      break;
+    }
+  }
+  if (indexToRemove !== -1) {
+    listOfSenders.splice(i, 1);
+    this._currentRTCRTPSenders[peerId] = listOfSenders;
+  } else {
+    log.warn([peerId, null, null, 'No matching sender was found for the peer'], sender);
+  }
+}

--- a/source/template/header.js
+++ b/source/template/header.js
@@ -917,4 +917,14 @@ function Skylink() {
    * @since 1.0.0
    */
   this._bufferedLocalOffer = {};
+
+  /**
+   * Map of RTCRTPSenders that are added via addTrack
+   * @attribute _currentRTCRTPSenders
+   * @type Object
+   * @private
+   * @for Skylink
+   * @since 1.0.0
+   */
+  this._currentRTCRTPSenders = {};
 }

--- a/source/template/header.js
+++ b/source/template/header.js
@@ -907,4 +907,14 @@ function Skylink() {
    * @since 1.0.0
    */
   this._originalDTLSRole = null;
+
+  /**
+   * Offer bufferred in order to apply when received answer
+   * @attribute _bufferedLocalOffer
+   * @type Object
+   * @private
+   * @for Skylink
+   * @since 1.0.0
+   */
+  this._bufferedLocalOffer = {};
 }


### PR DESCRIPTION
**Purpose of this PR:**

Needed for : New MCU and P2P

- When a peer offers it can call createOffer to generate a SDP offer and but use setLocalDescription immediately. 
- The peer will send the said created offer to the remote peer via SIG
- The remote peer will set the offer and send an answer back to the offering peer
- The offering peer, after having received the answer will now call setLocalDescription with the buffered offer
- On success of setting localDescription with the buffered offer, the peer can now call setRemoteDescription with the answer received

Nice detailed diagram by Miniruwan Mangala at https://bitbucket.org/TemasysCommunications/skylink-signalingspec/src/new-mcu/

See [ESS-1632](https://jira.temasys.com.sg/browse/ESS-1632) for more details. 