### PR TITLE
Fix Chrome iOS new UA string.

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -138,7 +138,7 @@ AdapterJS.parseWebrtcDetectedBrowser = function () {
   } else if (navigator.userAgent.indexOf('CriOS') > 0) {
     hasMatch = navigator.userAgent.match(/CriOS\/([0-9]+)\./) || [];
 
-    const iOSVersion = navigator.userAgent.match(/CPU OS ([0-9]+)_([0-9]+)/g);
+    const iOSVersion = navigator.userAgent.match(/CPU(?> iPhone| iPad)? OS ([0-9]+)_([0-9]+)/g);
     // iOS Version 14 and above supports webrtc
     const isCompatible = iOSVersion[0].split(' ')[2].split('_')[0] > 13;
     if (isCompatible) {


### PR DESCRIPTION
Chrome changed their user agent string, and the regexp you use breaks it.

The error is the following: `null is not an object (evaluating 'iOSVersion[0]')`
It is triggered here: https://github.com/Temasys/SkylinkJS/blob/2.x.x/master/src/adapter.js#L143
The new user agent string is: `Mozilla/5.0 (iPhone; CPU iPhone OS 14_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/92.0.4515.0 Mobile/15E148 Safari/604.1`
This new regex would work: `CPU(?> iPhone| iPad)? OS ([0-9]+)_([0-9]+)`